### PR TITLE
change font in build view to monospace

### DIFF
--- a/stylesheets/build.less
+++ b/stylesheets/build.less
@@ -30,6 +30,7 @@
     word-wrap: break-word;
     white-space: pre-wrap;
     list-style: none;
+    font-family: monospace;
   }
 
   li.error {


### PR DESCRIPTION
compilers like clang and rustc annotate errors with symbols to show where the error lies.
without a monospace font this is impossible to read

e.g.

```
D:\rust\src\librustdoc\lib.rs:19 #![feature(globs, struct_variant, macro_rules, phase, slicing_syntax, tuple_indexing)]
                                                   ^~~~~~~~~~~~~~
```
