### PR TITLE
Can not use 'Save and Build'

### DIFF
--- a/lib/save-confirm-view.js
+++ b/lib/save-confirm-view.js
@@ -53,7 +53,9 @@ module.exports = (function() {
 
   SaveConfirmView.prototype.saveAndConfirm = function() {
     _.each(atom.workspace.getTextEditors(), function(editor) {
-      editor.save();
+      if (editor.getLongTitle() != "untitled") {
+        editor.save();
+      }
     });
 
     if (this.confirmcb) {


### PR DESCRIPTION
A Workspace with a new file (never saved before) could not be 'saved and build' in one step because the new file does not have a path. But when I start Atom and open a project there was always a new file.