### PR TITLE
Add support for building Rust projects with Cargo

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -141,6 +141,11 @@ module.exports = {
       args = [ 'compile' ];
     }
 
+    if (!exec && fs.existsSync(root + '/Cargo.toml')) {
+      exec = 'cargo';
+      args = [ 'build' ];
+    }
+
     if (!exec && fs.existsSync(root + '/Makefile')) {
       exec = 'make';
       args = [];


### PR DESCRIPTION
Use `cargo build` to build projects if `Cargo.toml` exists in the root