### PR TITLE
Added setting to allow panel to remain open once process is killed

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -45,6 +45,12 @@ module.exports = {
       default: 0.15,
       minimum: 0.1,
       maximum: 0.9
+    },
+    closeOnFinish: {
+      title: 'Close panel on finish',
+      description: 'Close build panel when the process is killed',
+      type: 'boolean',
+      default: true
     }
   },
 
@@ -194,9 +200,11 @@ module.exports = {
     this.child.on('close', function(exitCode) {
       this.buildView.buildFinished(0 === exitCode);
       if (0 === exitCode) {
-        this.finishedTimer = setTimeout(function() {
-          this.buildView.detach();
-        }.bind(this), 1000);
+        if (atom.config.get('build.closeOnFinish')) {
+          this.finishedTimer = setTimeout(function() {
+            this.buildView.detach();
+          }.bind(this), 1000);
+        }
       }
       this.child = null;
     }.bind(this));


### PR DESCRIPTION
This is a bit of a problem that I found when using this package. Since the process that I open doesn't seem to spew out the outputs I want it to until it closes (not the packages's fault), I never get enough time to inspect it.
I managed to edit the package and add a setting for this, I would appreciate it if this setting was added to the package to help others who encountered the same problem.
I see you're currently changing things around so I couldn't properly test with the current file. However, on the latest release these changes worked perfectly.

Edit: Just noticed a spelling mistake in "Visisble", should probably fix that too