### PR TITLE
Cycling through match errors

### DIFF
--- a/keymaps/build.json
+++ b/keymaps/build.json
@@ -1,11 +1,13 @@
 {
   ".platform-darwin": {
     "cmd-alt-b": "build:trigger",
-    "cmd-alt-g": "build:error-match"
+    "cmd-alt-g": "build:error-match",
+    "cmd-alt-h": "build:error-match-first"
   },
   ".platform-linux, .platform-win32": {
     "ctrl-alt-b": "build:trigger",
-    "ctrl-alt-g": "build:error-match"
+    "ctrl-alt-g": "build:error-match",
+    "ctrl-alt-h": "build:error-match-first"
   },
   ".build": {
     "escape": "build:stop"

--- a/lib/build.js
+++ b/lib/build.js
@@ -61,6 +61,7 @@ module.exports = {
     this.stderr = new Buffer(0);
     atom.commands.add('atom-workspace', 'build:trigger', this.build.bind(this));
     atom.commands.add('atom-workspace', 'build:error-match', this.errorMatch.bind(this));
+    atom.commands.add('atom-workspace', 'build:error-match-first', this.errorMatchFirst.bind(this));
     atom.commands.add('atom-workspace', 'build:stop', this.stop.bind(this));
     atom.commands.add('atom-workspace', 'build:confirm', function() {
       document.activeElement.click();
@@ -136,28 +137,50 @@ module.exports = {
     return value;
   },
 
+  errorParse: function() {
+    this.match = [];
+    var regex = XRegExp(this.cmd.errorMatch);
+
+    var matchErr, matchOut;
+
+    matchErr = XRegExp.forEach(this.stderr.toString('utf8'), regex, function (match) {
+      return this.push(match);
+    }, []);
+
+    matchOut = XRegExp.forEach(this.stdout.toString('utf8'), regex, function (match) {
+      return this.push(match);
+    }, []);
+
+    this.match = matchErr.concat(matchOut);
+  },
+
   errorMatch: function() {
     if (!this.cmd.errorMatch) {
       return;
     }
+
     if (this.match.length == 0) {
-      var regex = XRegExp(this.cmd.errorMatch);
-
-      var matchErr, matchOut;
-
-      matchErr = XRegExp.forEach(this.stderr.toString('utf8'), regex, function (match) {
-        return this.push(match);
-      }, []);
-
-      matchOut = XRegExp.forEach(this.stdout.toString('utf8'), regex, function (match) {
-        return this.push(match);
-      }, []);
-
-      this.match = matchErr.concat(matchOut);
-
+      this.errorParse();
       if (this.match.length == 0) {
         return;
       }
+    }
+
+    atom.workspace.open(this.match[0].file, {
+      initialLine: this.match[0].line ? this.match[0].line - 1 : 0, /* Because atom is zero-based */
+      initialColumn: this.match[0].col ? this.match[0].col - 1 : 0 /* Because atom is zero-based */
+    });
+
+    this.match.push(this.match.shift());
+  },
+
+  errorMatchFirst: function() {
+    if (!this.cmd.errorMatch) {
+      return;
+    }
+    this.errorParse();
+    if (this.match.length == 0) {
+      return;
     }
 
     atom.workspace.open(this.match[0].file, {

--- a/lib/build.js
+++ b/lib/build.js
@@ -159,9 +159,9 @@ module.exports = {
       return;
     }
 
-    if (this.match.length == 0) {
+    if (this.match.length === 0) {
       this.errorParse();
-      if (this.match.length == 0) {
+      if (this.match.length === 0) {
         return;
       }
     }
@@ -179,7 +179,7 @@ module.exports = {
       return;
     }
     this.errorParse();
-    if (this.match.length == 0) {
+    if (this.match.length === 0) {
       return;
     }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -56,6 +56,7 @@ module.exports = {
 
     this.buildView = new BuildView();
     this.cmd = {};
+    this.match = [];
     this.stdout = new Buffer(0);
     this.stderr = new Buffer(0);
     atom.commands.add('atom-workspace', 'build:trigger', this.build.bind(this));
@@ -139,23 +140,37 @@ module.exports = {
     if (!this.cmd.errorMatch) {
       return;
     }
-    var regex = XRegExp(this.cmd.errorMatch);
-    var match =
-      XRegExp.exec(this.stderr.toString('utf8'), regex) ||
-      XRegExp.exec(this.stdout.toString('utf8'), regex);
+    if (this.match.length == 0) {
+      var regex = XRegExp(this.cmd.errorMatch);
 
-    if (!match) {
-      return;
+      var matchErr, matchOut;
+
+      matchErr = XRegExp.forEach(this.stderr.toString('utf8'), regex, function (match) {
+        return this.push(match);
+      }, []);
+
+      matchOut = XRegExp.forEach(this.stdout.toString('utf8'), regex, function (match) {
+        return this.push(match);
+      }, []);
+
+      this.match = matchErr.concat(matchOut);
+
+      if (this.match.length == 0) {
+        return;
+      }
     }
 
-    atom.workspace.open(match.file, {
-      initialLine: match.line ? match.line - 1 : 0, /* Because atom is zero-based */
-      initialColumn: match.col ? match.col - 1 : 0 /* Because atom is zero-based */
+    atom.workspace.open(this.match[0].file, {
+      initialLine: this.match[0].line ? this.match[0].line - 1 : 0, /* Because atom is zero-based */
+      initialColumn: this.match[0].col ? this.match[0].col - 1 : 0 /* Because atom is zero-based */
     });
+
+    this.match.push(this.match.shift());
   },
 
   startNewBuild: function() {
     this.cmd = {};
+    this.match = [];
     try {
       this.cmd = this.buildCommand();
     } catch (error) {

--- a/spec/build-spec.js
+++ b/spec/build-spec.js
@@ -24,6 +24,8 @@ describe('Build', function() {
   var syntaxErrorAtomBuildFile = __dirname + '/fixture/.atom-build.syntax-error.json';
   var errorMatchAtomBuildFile = __dirname + '/fixture/.atom-build.error-match.json';
   var errorMatchNLCAtomBuildFile = __dirname + '/fixture/.atom-build.error-match-no-line-col.json';
+  var errorMatchMultiAtomBuildFile = __dirname + '/fixture/.atom-build.error-match-multiple.json';
+  var errorMatchMultiFirstAtomBuildFile = __dirname + '/fixture/.atom-build.error-match-multiple-first.json';
 
   var directory = null;
   var workspaceElement = null;
@@ -786,6 +788,128 @@ describe('Build', function() {
       runs(function() {
         var editor = atom.workspace.getActiveTextEditor();
         expect(editor.getTitle()).toEqual('.atom-build.json');
+      });
+    });
+
+    it('should cycle through the file if multiple error occurred', function () {
+      expect(workspaceElement.querySelector('.build-confirm')).not.toExist();
+
+      fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchMultiAtomBuildFile));
+      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsFor(function() {
+        return workspaceElement.querySelector('.build .title').classList.contains('error');
+      });
+
+      runs(function() {
+        atom.commands.dispatch(workspaceElement, 'build:error-match');
+      });
+
+      waitsFor(function() {
+        return atom.workspace.getActiveTextEditor();
+      });
+
+      runs(function() {
+        var editor = atom.workspace.getActiveTextEditor();
+        var bufferPosition = editor.getCursorBufferPosition();
+        expect(editor.getTitle()).toEqual('.atom-build.json');
+        expect(bufferPosition.row).toEqual(2);
+        expect(bufferPosition.column).toEqual(7);
+        atom.workspace.getActivePane().destroyActiveItem();
+      });
+
+      runs(function() {
+        atom.commands.dispatch(workspaceElement, 'build:error-match');
+      });
+
+      waitsFor(function() {
+        return atom.workspace.getActiveTextEditor();
+      });
+
+      runs(function() {
+        var editor = atom.workspace.getActiveTextEditor();
+        var bufferPosition = editor.getCursorBufferPosition();
+        expect(editor.getTitle()).toEqual('.atom-build.json');
+        expect(bufferPosition.row).toEqual(1);
+        expect(bufferPosition.column).toEqual(4);
+        atom.workspace.getActivePane().destroyActiveItem();
+      });
+
+      runs(function() {
+        atom.commands.dispatch(workspaceElement, 'build:error-match');
+      });
+
+      waitsFor(function() {
+        return atom.workspace.getActiveTextEditor();
+      });
+
+      runs(function() {
+        var editor = atom.workspace.getActiveTextEditor();
+        var bufferPosition = editor.getCursorBufferPosition();
+        expect(editor.getTitle()).toEqual('.atom-build.json');
+        expect(bufferPosition.row).toEqual(2);
+        expect(bufferPosition.column).toEqual(7);
+      });
+    });
+
+    it('should jump to first error', function () {
+      expect(workspaceElement.querySelector('.build-confirm')).not.toExist();
+
+      fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchMultiFirstAtomBuildFile));
+      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsFor(function() {
+        return workspaceElement.querySelector('.build .title').classList.contains('error');
+      });
+
+      runs(function() {
+        atom.commands.dispatch(workspaceElement, 'build:error-match-first');
+      });
+
+      waitsFor(function() {
+        return atom.workspace.getActiveTextEditor();
+      });
+
+      runs(function() {
+        var editor = atom.workspace.getActiveTextEditor();
+        var bufferPosition = editor.getCursorBufferPosition();
+        expect(editor.getTitle()).toEqual('.atom-build.json');
+        expect(bufferPosition.row).toEqual(2);
+        expect(bufferPosition.column).toEqual(7);
+        atom.workspace.getActivePane().destroyActiveItem();
+      });
+
+      runs(function() {
+        atom.commands.dispatch(workspaceElement, 'build:error-match');
+      });
+
+      waitsFor(function() {
+        return atom.workspace.getActiveTextEditor();
+      });
+
+      runs(function() {
+        var editor = atom.workspace.getActiveTextEditor();
+        var bufferPosition = editor.getCursorBufferPosition();
+        expect(editor.getTitle()).toEqual('.atom-build.json');
+        expect(bufferPosition.row).toEqual(1);
+        expect(bufferPosition.column).toEqual(4);
+        atom.workspace.getActivePane().destroyActiveItem();
+      });
+
+      runs(function() {
+        atom.commands.dispatch(workspaceElement, 'build:error-match-first');
+      });
+
+      waitsFor(function() {
+        return atom.workspace.getActiveTextEditor();
+      });
+
+      runs(function() {
+        var editor = atom.workspace.getActiveTextEditor();
+        var bufferPosition = editor.getCursorBufferPosition();
+        expect(editor.getTitle()).toEqual('.atom-build.json');
+        expect(bufferPosition.row).toEqual(2);
+        expect(bufferPosition.column).toEqual(7);
       });
     });
   });

--- a/spec/fixture/.atom-build.error-match-multiple-first.json
+++ b/spec/fixture/.atom-build.error-match-multiple-first.json
@@ -1,0 +1,4 @@
+{
+	"cmd": "echo 'file:.atom-build.json,line:3,column:8\nfile:.atom-build.json,line:2,column:5\nfile:.atom-build.json,line:1,column:1' && return 1",
+	"errorMatch": "file:(?<file>[^,]+),line:(?<line>\\d+),column:(?<col>\\d+)"
+}

--- a/spec/fixture/.atom-build.error-match-multiple.json
+++ b/spec/fixture/.atom-build.error-match-multiple.json
@@ -1,0 +1,4 @@
+{
+	"cmd": "echo 'file:.atom-build.json,line:3,column:8\nfile:.atom-build.json,line:2,column:5' && return 1",
+	"errorMatch": "file:(?<file>[^,]+),line:(?<line>\\d+),column:(?<col>\\d+)"
+}


### PR DESCRIPTION
Instead of only allowing to jump to the first location found by the given errorMatch regular expression, you can cycle through every error with build:error-match. At the end it loops around to the beginning.
build:error-match-first (cmd-alt-h) jumps directly back to the beginning.