### PR TITLE
Add build:toggle-view command

### DIFF
--- a/keymaps/build.json
+++ b/keymaps/build.json
@@ -1,11 +1,13 @@
 {
   ".platform-darwin": {
     "cmd-alt-b": "build:trigger",
+    "cmd-alt-b cmd-alt-v": "build:toggle-view",
     "cmd-alt-g": "build:error-match",
     "cmd-alt-h": "build:error-match-first"
   },
   ".platform-linux, .platform-win32": {
     "ctrl-alt-b": "build:trigger",
+    "ctrl-alt-b ctrl-alt-v": "build:toggle-view",
     "ctrl-alt-g": "build:error-match",
     "ctrl-alt-h": "build:error-match-first"
   },

--- a/keymaps/build.json
+++ b/keymaps/build.json
@@ -1,13 +1,13 @@
 {
   ".platform-darwin": {
     "cmd-alt-b": "build:trigger",
-    "cmd-alt-v": "build:toggle-view",
+    "cmd-alt-v": "build:toggle-panel",
     "cmd-alt-g": "build:error-match",
     "cmd-alt-h": "build:error-match-first"
   },
   ".platform-linux, .platform-win32": {
     "ctrl-alt-b": "build:trigger",
-    "ctrl-alt-v": "build:toggle-view",
+    "ctrl-alt-v": "build:toggle-panel",
     "ctrl-alt-g": "build:error-match",
     "ctrl-alt-h": "build:error-match-first"
   },

--- a/keymaps/build.json
+++ b/keymaps/build.json
@@ -1,13 +1,13 @@
 {
   ".platform-darwin": {
     "cmd-alt-b": "build:trigger",
-    "cmd-alt-b cmd-alt-v": "build:toggle-view",
+    "cmd-alt-v": "build:toggle-view",
     "cmd-alt-g": "build:error-match",
     "cmd-alt-h": "build:error-match-first"
   },
   ".platform-linux, .platform-win32": {
     "ctrl-alt-b": "build:trigger",
-    "ctrl-alt-b ctrl-alt-v": "build:toggle-view",
+    "ctrl-alt-v": "build:toggle-view",
     "ctrl-alt-g": "build:error-match",
     "ctrl-alt-h": "build:error-match-first"
   },

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -22,6 +22,8 @@ module.exports = (function() {
     atom.config.observe('build.panelVisibility', this.visibleFromConfig.bind(this));
     atom.config.observe('build.monocleHeight', this.heightFromConfig.bind(this));
     atom.config.observe('build.minimizedHeight', this.heightFromConfig.bind(this));
+
+    atom.commands.add('atom-workspace', 'build:toggle-view', this.toggle.bind(this));
   }
 
   cscompatability.extends(BuildView, View);

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -23,7 +23,7 @@ module.exports = (function() {
     atom.config.observe('build.monocleHeight', this.heightFromConfig.bind(this));
     atom.config.observe('build.minimizedHeight', this.heightFromConfig.bind(this));
 
-    atom.commands.add('atom-workspace', 'build:toggle-view', this.toggle.bind(this));
+    atom.commands.add('atom-workspace', 'build:toggle-panel', this.toggle.bind(this));
   }
 
   cscompatability.extends(BuildView, View);

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -68,6 +68,10 @@ module.exports = (function() {
     }
   };
 
+  BuildView.prototype.isAttached = function() {
+    return !!this.panel;
+  };
+
   BuildView.prototype.heightFromConfig = function(val) {
     if (this.monocle) {
       this.setHeightPercent(atom.config.get('build.monocleHeight'));
@@ -108,6 +112,14 @@ module.exports = (function() {
 
   BuildView.prototype.close = function(event, element) {
     this.detach(true);
+  };
+
+  BuildView.prototype.toggle = function(event, element) {
+    if (this.isAttached()) {
+      this.detach(true);
+    } else {
+      this.attach();
+    }
   };
 
   BuildView.prototype.clear = function(event, element) {

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -115,11 +115,7 @@ module.exports = (function() {
   };
 
   BuildView.prototype.toggle = function(event, element) {
-    if (this.isAttached()) {
-      this.detach(true);
-    } else {
-      this.attach();
-    }
+    this.isAttached() ?  this.detach(true) : this.attach(true);
   };
 
   BuildView.prototype.clear = function(event, element) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -72,6 +72,7 @@ module.exports = {
     this.stdout = new Buffer(0);
     this.stderr = new Buffer(0);
     atom.commands.add('atom-workspace', 'build:trigger', this.build.bind(this));
+    atom.commands.add('atom-workspace', 'build:toggle-view', this.toggleView.bind(this));
     atom.commands.add('atom-workspace', 'build:error-match', this.errorMatch.bind(this));
     atom.commands.add('atom-workspace', 'build:error-match-first', this.errorMatchFirst.bind(this));
     atom.commands.add('atom-workspace', 'build:stop', this.stop.bind(this));
@@ -287,6 +288,10 @@ module.exports = {
         this.startNewBuild();
       }
     }.bind(this));
+  },
+
+  toggleView: function() {
+    this.buildView.toggle();
   },
 
   doSaveConfirm: function(modifiedTextEditors, continuecb, cancelcb) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -72,7 +72,6 @@ module.exports = {
     this.stdout = new Buffer(0);
     this.stderr = new Buffer(0);
     atom.commands.add('atom-workspace', 'build:trigger', this.build.bind(this));
-    atom.commands.add('atom-workspace', 'build:toggle-view', this.toggleView.bind(this));
     atom.commands.add('atom-workspace', 'build:error-match', this.errorMatch.bind(this));
     atom.commands.add('atom-workspace', 'build:error-match-first', this.errorMatchFirst.bind(this));
     atom.commands.add('atom-workspace', 'build:stop', this.stop.bind(this));
@@ -288,10 +287,6 @@ module.exports = {
         this.startNewBuild();
       }
     }.bind(this));
-  },
-
-  toggleView: function() {
-    this.buildView.toggle();
   },
 
   doSaveConfirm: function(modifiedTextEditors, continuecb, cancelcb) {

--- a/spec/build-spec.js
+++ b/spec/build-spec.js
@@ -971,11 +971,11 @@ describe('Build', function() {
     });
   });
 
-  describe('when build window is toggled and it is not visible', function() {
-    it('should show the build window', function() {
+  describe('when build panel is toggled and it is not visible', function() {
+    it('should show the build panel', function() {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
-      atom.commands.dispatch(workspaceElement, 'build:toggle-view');
+      atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
 
       expect(workspaceElement.querySelector('.build')).toExist();
     });

--- a/spec/build-spec.js
+++ b/spec/build-spec.js
@@ -970,4 +970,14 @@ describe('Build', function() {
       });
     });
   });
+
+  describe('when build window is toggled and it is not visible', function() {
+    it('should show the build window', function() {
+      expect(workspaceElement.querySelector('.build')).not.toExist();
+
+      atom.commands.dispatch(workspaceElement, 'build:toggle-view');
+
+      expect(workspaceElement.querySelector('.build')).toExist();
+    });
+  });
 });

--- a/spec/build-visible-spec.js
+++ b/spec/build-visible-spec.js
@@ -22,4 +22,14 @@ describe('Build', function() {
       expect(workspaceElement.querySelector('.build')).toExist();
     });
   });
+
+  describe('when build window is toggled and it is visible', function() {
+    it('should hide the build window', function() {
+      expect(workspaceElement.querySelector('.build')).toExist();
+
+      atom.commands.dispatch(workspaceElement, 'build:toggle-view');
+
+      expect(workspaceElement.querySelector('.build')).not.toExist();
+    });
+  });
 });

--- a/spec/build-visible-spec.js
+++ b/spec/build-visible-spec.js
@@ -23,11 +23,11 @@ describe('Build', function() {
     });
   });
 
-  describe('when build window is toggled and it is visible', function() {
-    it('should hide the build window', function() {
+  describe('when build panel is toggled and it is visible', function() {
+    it('should hide the build panel', function() {
       expect(workspaceElement.querySelector('.build')).toExist();
 
-      atom.commands.dispatch(workspaceElement, 'build:toggle-view');
+      atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
 
       expect(workspaceElement.querySelector('.build')).not.toExist();
     });


### PR DESCRIPTION
This command allows you to show or hide the build view. The default shortcut is `cmd-alt-b cmd-alt-v` (Mac) or `ctrl-alt-b ctrl-alt-v` (others).
