### PR TITLE
Add timeout to dismiss build view

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ exactly what to execute. Create a file named `.atom-build.json` in your project 
         "VARIABLE2": "VALUE2",
         ...
       },
-      "errorMatch": "^regexp$"
+      "errorMatch": "^regexp$",
+      "buildViewTimeout": 1000
     }
 
 Note that if `sh` is false `cmd` must only be the executable - no arguments here. If the
@@ -65,6 +66,7 @@ systems).
   * `cwd` - **[optional]** The working directory for the command. E.g. what `.` resolves to.
   * `env` - **[optional]** An array of environment variables and their values to set
   * `errorMatch` - **[optional]** A regular expression to match output to a file, row and col. See [Error matching](#error-match) for details.
+  * `buildViewTimeout` - **[optional]** Interval in milliseconds to dismiss build view
 
 ### Replacements
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -118,7 +118,8 @@ module.exports = {
       args: [],
       cwd: path,
       sh: true,
-      errorMatch: ''
+      errorMatch: '',
+      buildViewTimeout: 1000
     };
     _.find(tools, function (tool) {
       if (!tool.isEligable(path)) {
@@ -256,7 +257,7 @@ module.exports = {
       if (0 === exitCode) {
         this.finishedTimer = setTimeout(function() {
           this.buildView.detach();
-        }.bind(this), 1000);
+        }.bind(this), this.buildCommand().buildViewTimeout);
       }
       this.child = null;
     }.bind(this));


### PR DESCRIPTION
#### What is changed
Gives control of the build view dismiss time interval back to users. Reads optional key `buildViewTimeout` from `atom-build.json`. Default is 1 second.

Let me know if you would like to name the key something else and I'll follow suit. Any other comments/suggestions are welcome.

#### Reason
I was building a Go file one at a time using `go run` and wanted to analyse the output in the build view without switching windows. But the build view was closing after 1 second making it difficult for me to look at the output of the program.