### PR TITLE
Choose to steal focus

### DIFF
--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -148,7 +148,9 @@ module.exports = (function() {
   BuildView.prototype.buildStarted = function() {
     this.reset();
     this.attach();
-    this.focus();
+    if (atom.config.get('build.stealFocus')) {
+      this.focus();
+    }
     this.updateTitle();
   };
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -34,6 +34,13 @@ module.exports = {
       default: false,
       order: 3
     },
+    stealFocus: {
+      title: 'Steal Focus',
+      description: 'Steal focus when opening build panel.',
+      type: 'boolean',
+      default: true,
+      order: 4
+    },
     monocleHeight: {
       title: 'Monocle Height',
       description: 'How much of the workspace to use for build panel when it is "maximized".',
@@ -41,7 +48,7 @@ module.exports = {
       default: 0.75,
       minimum: 0.1,
       maximum: 0.9,
-      order: 4
+      order: 5
     },
     minimizedHeight: {
       title: 'Minimized Height',
@@ -50,7 +57,7 @@ module.exports = {
       default: 0.15,
       minimum: 0.1,
       maximum: 0.9,
-      order: 5
+      order: 6
     }
   },
 


### PR DESCRIPTION
- Add a `stealFocus` setting
- Read this setting when starting the build, to steal, or not, the focus.

Do not steal focus enable to continue coding when building the project.
More code, more fun ! :tada: