### PR TITLE
Panel Orientation

### DIFF
--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -60,14 +60,17 @@ module.exports = (function() {
 
     if ('Top' === atom.config.get('build.panelOrientation')) {
         this.panel = atom.workspace.addTopPanel({ item: this });
+        this.height = this.output.offset().top + this.output.width();
     } else if ('Bottom' === atom.config.get('build.panelOrientation')) {
         this.panel = atom.workspace.addBottomPanel({ item: this });
+        this.height = this.output.offset().top + this.output.width();
     } else if ('Left' === atom.config.get('build.panelOrientation')) {
         this.panel = atom.workspace.addLeftPanel({ item: this });
+        this.height = this.output.offset().top + this.output.width();
     } else if ('Right' === atom.config.get('build.panelOrientation')) {
         this.panel = atom.workspace.addRightPanel({ item: this });
+        this.height = this.output.offset().top + this.output.width();
     }
-    this.height = this.output.offset().top + this.output.height();
   };
 
   BuildView.prototype.detach = function(force) {
@@ -143,7 +146,11 @@ module.exports = (function() {
 
   BuildView.prototype.setHeightPercent = function(percent) {
     var newHeight = percent * this.height;
-    this.output.css('height', newHeight + 'px');
+    if ('Left' === atom.config.get('build.panelOrientation') || 'Right' === atom.config.get('build.panelOrientation')){
+        this.output.css('width', newHeight + 'px');
+    } else {
+        this.output.css('height', newHeight + 'px');
+    }
   };
 
   BuildView.prototype.toggleMonocle = function(event, element) {

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -60,10 +60,10 @@ module.exports = (function() {
 
     if ('Top' === atom.config.get('build.panelOrientation')) {
         this.panel = atom.workspace.addTopPanel({ item: this });
-        this.height = this.output.offset().top + this.output.width();
+        this.height = this.output.offset().top + this.output.height();
     } else if ('Bottom' === atom.config.get('build.panelOrientation')) {
         this.panel = atom.workspace.addBottomPanel({ item: this });
-        this.height = this.output.offset().top + this.output.width();
+        this.height = this.output.offset().top + this.output.height();
     } else if ('Left' === atom.config.get('build.panelOrientation')) {
         this.panel = atom.workspace.addLeftPanel({ item: this });
         this.height = this.output.offset().top + this.output.width();

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -21,6 +21,7 @@ module.exports = (function() {
     this.attach();
 
     atom.config.observe('build.panelVisibility', this.visibleFromConfig.bind(this));
+    atom.config.observe('build.panelOrientation', this.visibleFromConfig.bind(this));
     atom.config.observe('build.monocleHeight', this.heightFromConfig.bind(this));
     atom.config.observe('build.minimizedHeight', this.heightFromConfig.bind(this));
 
@@ -56,7 +57,16 @@ module.exports = (function() {
     if (this.panel) {
       this.panel.destroy();
     }
-    this.panel = atom.workspace.addBottomPanel({ item: this });
+
+    if ('Top' === atom.config.get('build.panelOrientation')) {
+        this.panel = atom.workspace.addTopPanel({ item: this });
+    } else if ('Bottom' === atom.config.get('build.panelOrientation')) {
+        this.panel = atom.workspace.addBottomPanel({ item: this });
+    } else if ('Left' === atom.config.get('build.panelOrientation')) {
+        this.panel = atom.workspace.addLeftPanel({ item: this });
+    } else if ('Right' === atom.config.get('build.panelOrientation')) {
+        this.panel = atom.workspace.addRightPanel({ item: this });
+    }
     this.height = this.output.offset().top + this.output.height();
   };
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -21,26 +21,34 @@ module.exports = {
       enum: [ 'Toggle', 'Keep Visible', 'Show on Error' ],
       order: 1
     },
+    panelOrientation: {
+      title: 'Panel Orientation',
+      description: 'Set where the build panel should be.',
+      type: 'string',
+      default: 'Bottom',
+      enum: [ 'Top', 'Bottom', 'Left', 'Right' ],
+      order: 2
+    },
     buildOnSave: {
       title: 'Automatically build on save',
       description: 'Autmatically build your project each time an editor is saved.',
       type: 'boolean',
       default: false,
-      order: 2
+      order: 3
     },
     saveOnBuild: {
       title: 'Automatically save on build',
       description: 'Automatically save all edited files when triggering a build.',
       type: 'boolean',
       default: false,
-      order: 3
+      order: 4
     },
     stealFocus: {
       title: 'Steal Focus',
       description: 'Steal focus when opening build panel.',
       type: 'boolean',
       default: true,
-      order: 4
+      order: 5
     },
     monocleHeight: {
       title: 'Monocle Height',
@@ -49,7 +57,7 @@ module.exports = {
       default: 0.75,
       minimum: 0.1,
       maximum: 0.9,
-      order: 5
+      order: 6
     },
     minimizedHeight: {
       title: 'Minimized Height',
@@ -58,7 +66,7 @@ module.exports = {
       default: 0.15,
       minimum: 0.1,
       maximum: 0.9,
-      order: 6
+      order: 7
     }
   },
 


### PR DESCRIPTION
Alright, so I'm looking through the files and I can see most of what I need to change to make this happen I believe is in build.js and build-view.js. So I looked through, trying to see what's what. Trying to insert what I think is necessary.

I'm sure I missed some things, and I'd like so mention what I know to be a bug or something.

First thing... I made a spelling mistake, I fixed it... But it seems to keep this around:
![something_wrong](https://cloud.githubusercontent.com/assets/8561784/7899502/cfb1e7ac-06d9-11e5-93a3-2043931a63cf.png)

Next, I was looking around, because  when I built when in left or right orientation, it took up a very large portion of the window. That's useless because I have the "height" at a very low percentage. I thought if I changed the css output to width and/or changed this.output.height to this.output.width it would change it but I'm ignorant in this field. It obviously didn't work out too well, now I can't get it big enough.

I did however succeed in getting the panel to orientate where I wanted. So that's cool. Obviously though, I'd like to get these things fixed.

Also, I didn't know what to rename height to. I was thinking length, but I thought that could be misleading as well. But I'm not sure.