### PR TITLE
Fix bug that prevents error matching on successfull build command

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -300,14 +300,16 @@ module.exports = {
 
         this.child.on('close', function(exitCode) {
           this.buildView.buildFinished(0 === exitCode);
+
+          var t = this.targets[this.activeTarget];
+          this.errorMatcher.set(t.errorMatch, this.replace(t.cwd), Buffer.concat([ this.stdout, this.stderr ]).toString('utf8'));
+
           if (0 === exitCode) {
             GoogleAnalytics.sendEvent('build', 'succeeded');
             this.finishedTimer = setTimeout(function() {
               this.buildView.detach();
             }.bind(this), 1000);
           } else {
-            var t = this.targets[this.activeTarget];
-            this.errorMatcher.set(t.errorMatch, this.replace(t.cwd), Buffer.concat([ this.stdout, this.stderr ]).toString('utf8'));
             if (atom.config.get('build.scrollOnError')) {
               this.errorMatcher.matchFirst();
             }


### PR DESCRIPTION
In it's previous place these two lines only allowed error matching if the build command returned a nonzero value.

This prevented cycling through warnings that didn't make the build exit with an error.