### PR TITLE
Search all panes when opening a matched file

### DIFF
--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -40,7 +40,8 @@ module.exports = (function () {
       }
       atom.workspace.open(file, {
         initialLine: row,
-        initialColumn: col
+        initialColumn: col,
+        searchAllPanes: true
       });
       this.currentMatch.push(this.currentMatch.shift());
     }.bind(this));


### PR DESCRIPTION
A simple change, which makes working with multiple panes and atom-build easier. Before this patch I would end up with multiple files opened in all panes.