### PR TITLE
Only use project path if it contains active file

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -274,7 +274,7 @@ module.exports = {
       value = value.replace('{FILE_ACTIVE_NAME}', path.basename(activeFile));
       value = value.replace('{FILE_ACTIVE_NAME_BASE}', path.basename(activeFile, path.extname(activeFile)));
     }
-    var projectPaths = _.map(atom.project.getPaths(), function(projectPath) { try { return fs.realpathSync(projectPath); } catch(e) {} });
+    var projectPaths = _.map(atom.project.getPaths(), function(projectPath) { try { return fs.realpathSync(projectPath); } catch (e) {} });
     var projectPath = _.find(projectPaths, function(projectPath) { return activeFilePath && activeFilePath.startsWith(projectPath); }) || projectPaths[0];
     value = value.replace('{PROJECT_PATH}', projectPath);
     if (atom.project.getRepositories[0]) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -268,13 +268,16 @@ module.exports = {
     var editor = atom.workspace.getActiveTextEditor();
     if (editor && 'untitled' !== editor.getTitle()) {
       var activeFile = fs.realpathSync(editor.getPath());
+      var activeFilePath = path.dirname(activeFile);
       value = value.replace('{FILE_ACTIVE}', activeFile);
-      value = value.replace('{FILE_ACTIVE_PATH}', path.dirname(activeFile));
+      value = value.replace('{FILE_ACTIVE_PATH}', activeFilePath);
       value = value.replace('{FILE_ACTIVE_NAME}', path.basename(activeFile));
       value = value.replace('{FILE_ACTIVE_NAME_BASE}', path.basename(activeFile, path.extname(activeFile)));
     }
-
-    value = value.replace('{PROJECT_PATH}', fs.realpathSync(atom.project.getPaths()[0]));
+    var projectPaths = atom.project.getPaths().map(function(projectPath) { return fs.realpathSync(projectPath); });
+    var projectPath = projectPaths.filter(function(projectPath) { return activeFilePath.startsWith(projectPath); })[0];
+    if (!projectPath) { projectPath = projectPaths[0]; }
+    value = value.replace('{PROJECT_PATH}', projectPath);
     if (atom.project.getRepositories[0]) {
       value = value.replace('{REPO_BRANCH_SHORT}', atom.project.getRepositories()[0].getShortHead());
     }

--- a/lib/build.js
+++ b/lib/build.js
@@ -274,9 +274,8 @@ module.exports = {
       value = value.replace('{FILE_ACTIVE_NAME}', path.basename(activeFile));
       value = value.replace('{FILE_ACTIVE_NAME_BASE}', path.basename(activeFile, path.extname(activeFile)));
     }
-    var projectPaths = atom.project.getPaths().map(function(projectPath) { return fs.realpathSync(projectPath); });
-    var projectPath = projectPaths.filter(function(projectPath) { return activeFilePath.startsWith(projectPath); })[0];
-    if (!projectPath) { projectPath = projectPaths[0]; }
+    var projectPaths = _.map(atom.project.getPaths(), function(projectPath) { try { return fs.realpathSync(projectPath); } catch(e) {} });
+    var projectPath = _.find(projectPaths, function(projectPath) { return activeFilePath && activeFilePath.startsWith(projectPath); }) || projectPaths[0];
     value = value.replace('{PROJECT_PATH}', projectPath);
     if (atom.project.getRepositories[0]) {
       value = value.replace('{REPO_BRANCH_SHORT}', atom.project.getRepositories()[0].getShortHead());


### PR DESCRIPTION
This problem was exposed since I'm using [tree-view-git-projects](https://github.com/JavascriptIsMagic/tree-view-git-projects), and it re-sorts projects. This should also help in other cases when users have multiple root folders.