### PR TITLE
wip: load&activate performance

### DIFF
--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -18,7 +18,6 @@ module.exports = (function() {
     this.titleLoopIndex = 0;
     this.a2h = new Convert();
     this.monocle = false;
-    this.attach();
 
     atom.config.observe('build.panelVisibility', this.visibleFromConfig.bind(this));
     atom.config.observe('build.monocleHeight', this.heightFromConfig.bind(this));
@@ -94,10 +93,6 @@ module.exports = (function() {
         if (!this.title.hasClass('error')) {
           this.detach();
         }
-        break;
-
-      case 'Keep Visible':
-        this.attach();
         break;
     }
   };

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,18 +1,13 @@
 'use strict';
 
-var child_process = require('child_process');
 var Promise = require('bluebird');
 var fs = Promise.promisifyAll(require('fs'));
 var path = require('path');
 var _ = require('lodash');
-var Promise = require('bluebird');
 
 var SaveConfirmView = require('./save-confirm-view');
-var TargetsView = require('./targets-view');
 var BuildView = require('./build-view');
 var GoogleAnalytics = require('./google-analytics');
-var ErrorMatcher = require('./error-matcher');
-var tools = require('./tools');
 
 function BuildError(name, message) {
   this.name = name;
@@ -95,7 +90,6 @@ module.exports = {
     this.match = [];
     this.stdout = new Buffer(0);
     this.stderr = new Buffer(0);
-    this.errorMatcher = new ErrorMatcher();
 
     atom.commands.add('atom-workspace', 'build:trigger', this.build.bind(this));
     atom.commands.add('atom-workspace', 'build:select-active-target', this.selectActiveTarget.bind(this));
@@ -116,10 +110,6 @@ module.exports = {
           atom.commands.dispatch(workspaceElement, 'build:trigger');
         }
       });
-    });
-
-    this.errorMatcher.on('error', function (message) {
-      atom.notifications.addError('Error matching failed!', { detail: message });
     });
   },
 
@@ -162,6 +152,7 @@ module.exports = {
   },
 
   refreshTargets: function() {
+    var tools = require('./tools');
     var path = this.activePath();
     var prioritizedTarget;
     var customFile = path + '/.atom-build.json';
@@ -216,6 +207,7 @@ module.exports = {
   },
 
   selectActiveTarget: function() {
+    var TargetsView = require('./targets-view');
     var targetsView = new TargetsView();
     targetsView.setLoading('Loading project build targets...\u2026');
 
@@ -259,8 +251,15 @@ module.exports = {
   },
 
   startNewBuild: function() {
+    var child_process = require('child_process');
     this.cmd = {};
     this.match = [];
+
+    var ErrorMatcher = require('./error-matcher');
+    this.errorMatcher = new ErrorMatcher();
+    this.errorMatcher.on('error', function (message) {
+      atom.notifications.addError('Error matching failed!', { detail: message });
+    });
 
     Promise.resolve()
       .bind(this)

--- a/spec/build-spec.js
+++ b/spec/build-spec.js
@@ -65,7 +65,7 @@ describe('Build', function() {
     it('should not leave multiple panels behind', function() {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
-      atom.config.set('build.panelVisibility', 'Keep Visible');
+      atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
 
       fs.writeFileSync(directory + 'Makefile', fs.readFileSync(goodMakefile));
       atom.commands.dispatch(workspaceElement, 'build:trigger');

--- a/spec/build-visible-spec.js
+++ b/spec/build-visible-spec.js
@@ -45,8 +45,8 @@ describe('Visible', function() {
       });
     });
 
-    it('should show build window', function() {
-      expect(workspaceElement.querySelector('.build')).toExist();
+    it('should show not build window', function() {
+      expect(workspaceElement.querySelector('.build')).not.toExist();
     });
   });
 
@@ -60,7 +60,7 @@ describe('Visible', function() {
 
     describe('when build panel is toggled and it is visible', function() {
       beforeEach(function () {
-        atom.config.set('build.panelVisibility', 'Keep Visible');
+        atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
         waitsForPromise(function () {
           return atom.packages.activatePackage('build');
         });


### PR DESCRIPTION
for #109 

Shifting some requires around yields some improvement, but also adds some duplication. The real win would be in not creating a BuildView on activate but on the first time a build is run. That would drop the activation time from ~ 150 to 15ms (load time around 40ms). Coincidentally that would also solve #108 where a build panel is shown even though no build has been run.
There is no need to run create any views until there is a need to do so, so that should be possible (with some work). That mirrors my experience with terminal-panel, where creating the view was the most expensive as well.

Edit: my tinkering is mostly inconsequential, some milliseconds here and there. Ideally BuildView should only be done the first time a build is run, that would save almost 150ms, of 75% of the current startup time for atom-build. It would take me a bit more time than I have right now to figure out how to do that, but perhaps it sets you on your way.