### PR TITLE
don't attach view on package activation

### DIFF
--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -18,7 +18,7 @@ module.exports = (function() {
     this.titleLoopIndex = 0;
     this.a2h = new Convert();
     this.monocle = false;
-    this.attach();
+    // this.attach();
 
     atom.config.observe('build.panelVisibility', this.visibleFromConfig.bind(this));
     atom.config.observe('build.monocleHeight', this.heightFromConfig.bind(this));
@@ -95,10 +95,10 @@ module.exports = (function() {
           this.detach();
         }
         break;
-
-      case 'Keep Visible':
-        this.attach();
-        break;
+      //
+      // case 'Keep Visible':
+      //   this.attach();
+      //   break;
     }
   };
 

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -18,7 +18,6 @@ module.exports = (function() {
     this.titleLoopIndex = 0;
     this.a2h = new Convert();
     this.monocle = false;
-    // this.attach();
 
     atom.config.observe('build.panelVisibility', this.visibleFromConfig.bind(this));
     atom.config.observe('build.monocleHeight', this.heightFromConfig.bind(this));
@@ -95,10 +94,6 @@ module.exports = (function() {
           this.detach();
         }
         break;
-      //
-      // case 'Keep Visible':
-      //   this.attach();
-      //   break;
     }
   };
 

--- a/spec/build-spec.js
+++ b/spec/build-spec.js
@@ -65,7 +65,7 @@ describe('Build', function() {
     it('should not leave multiple panels behind', function() {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
-      atom.config.set('build.panelVisibility', 'Keep Visible');
+      atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
 
       fs.writeFileSync(directory + 'Makefile', fs.readFileSync(goodMakefile));
       atom.commands.dispatch(workspaceElement, 'build:trigger');

--- a/spec/build-visible-spec.js
+++ b/spec/build-visible-spec.js
@@ -45,8 +45,8 @@ describe('Visible', function() {
       });
     });
 
-    it('should show build window', function() {
-      expect(workspaceElement.querySelector('.build')).toExist();
+    it('should not show build window', function() {
+      expect(workspaceElement.querySelector('.build')).not.toExist();
     });
   });
 
@@ -60,10 +60,7 @@ describe('Visible', function() {
 
     describe('when build panel is toggled and it is visible', function() {
       beforeEach(function () {
-        atom.config.set('build.panelVisibility', 'Keep Visible');
-        waitsForPromise(function () {
-          return atom.packages.activatePackage('build');
-        });
+        atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
       });
 
       it('should hide the build panel', function() {


### PR DESCRIPTION
fix for #108 

I think the idea behind the option "Keep visibile" would be to keep the build output visible after a build, not to have the build output panel visible at all times. Package activation happens each time a new atom window is opened and it doesn't seem useful to me to have the build panel open right away (with no output).

I could be wrong though, and perhaps another option is needed. In any case, this PR changes the behaviour to keep the panel visible after a successful build, but not immediately after package activation.