### PR TITLE
Atom Linter support for build errors/warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Atom Build package
-[![Build Travis](https://travis-ci.org/noseglid/atom-build.svg?branch=master)](https://travis-ci.org/noseglid/atom-build)
+[![Build Travis](https://travis-ci.org/noseglid/atom-build.svg?branch=master)](https://travis-ci.org/debuuu/atom-build)
 [![Gitter chat](https://badges.gitter.im/noseglid/atom-build.svg)](https://gitter.im/noseglid/atom-build)
 
 Automatically build your project inside your new favorite editor, Atom.

--- a/lib/build.js
+++ b/lib/build.js
@@ -310,12 +310,12 @@ module.exports = {
           this.buildView.append((this.cmd.sh ? 'Unable to execute with sh: ' : 'Unable to execute: ') + this.cmd.exec);
           this.buildView.append(/\s/.test(this.cmd.exec) ? '`cmd` cannot contain space. Use `args` for arguments.' : '');
         }.bind(this));
-        
+
         this.child.on('close', function(exitCode) {
           this.buildView.buildFinished(0 === exitCode);
           if (0 === exitCode) {
             // if the command has a linter, clear lints for successful builds.
-            if (this.cmd.linter != undefined) {
+            if (this.cmd.linter !== undefined) {
                 this.cmd.linter.setLinter(this.linter);
                 this.cmd.linter.clearLint();
             }
@@ -325,7 +325,7 @@ module.exports = {
             }.bind(this), 1000);
           } else {
             // if the command has a linter, send output buffers to linter helper.
-            if (this.cmd.linter != undefined) {
+            if (this.cmd.linter !== undefined) {
                 this.cmd.linter.setLinter(this.linter);
                 this.cmd.linter.updateLint(Buffer.concat([ this.stdout, this.stderr ]).toString('utf8'), this.cmd.errorMatch);
             }

--- a/lib/build.js
+++ b/lib/build.js
@@ -306,6 +306,11 @@ module.exports = {
           this.buildView.append(buffer);
         }.bind(this));
 
+        this.child.on('error', function(err) {
+          this.buildView.append((this.cmd.sh ? 'Unable to execute with sh: ' : 'Unable to execute: ') + this.cmd.exec);
+          this.buildView.append(/\s/.test(this.cmd.exec) ? '`cmd` cannot contain space. Use `args` for arguments.' : '');
+        }.bind(this));
+        
         this.child.on('close', function(exitCode) {
           this.buildView.buildFinished(0 === exitCode);
           if (0 === exitCode) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -61,6 +61,13 @@ module.exports = {
       default: true,
       order: 5
     },
+    showBuildNotifications: {
+      title: 'Show build notifications',
+      description: 'Show notifications when builds succeed or fail.',
+      type: 'boolean',
+      default: true,
+      order: 6
+    },
     monocleHeight: {
       title: 'Monocle Height',
       description: 'How much of the workspace to use for build panel when it is "maximized".',
@@ -68,7 +75,7 @@ module.exports = {
       default: 0.75,
       minimum: 0.1,
       maximum: 0.9,
-      order: 6
+      order: 7
     },
     minimizedHeight: {
       title: 'Minimized Height',
@@ -77,8 +84,8 @@ module.exports = {
       default: 0.15,
       minimum: 0.1,
       maximum: 0.9,
-      order: 7
-    }
+      order: 8
+    },
   },
 
   activate: function(state) {
@@ -320,6 +327,9 @@ module.exports = {
                 this.cmd.linter.clearLint();
             }
             GoogleAnalytics.sendEvent('build', 'succeeded');
+            if (atom.config.get('build.showBuildNotifications')) {
+              atom.notifications.addSuccess('Build successful.');
+            }
             this.finishedTimer = setTimeout(function() {
               this.buildView.detach();
             }.bind(this), 1000);
@@ -334,6 +344,9 @@ module.exports = {
               this.errorMatcher.matchFirst();
             }
             GoogleAnalytics.sendEvent('build', 'failed');
+            if (atom.config.get('build.showBuildNotifications')) {
+              atom.notifications.addError('Build failed!');
+            }
           }
           this.child = null;
         }.bind(this));

--- a/lib/build.js
+++ b/lib/build.js
@@ -122,7 +122,10 @@ module.exports = {
       atom.notifications.addError('Error matching failed!', { detail: message });
     });
   },
-
+  // receives the Linter object from Atom Linter package.
+  consumeLinter: function(linter) {
+    this.linter = linter;
+  },
   deactivate: function() {
     if (this.customFileWatcher) {
       this.customFileWatcher.close();
@@ -303,21 +306,25 @@ module.exports = {
           this.buildView.append(buffer);
         }.bind(this));
 
-        this.child.on('error', function(err) {
-          this.buildView.append((this.cmd.sh ? 'Unable to execute with sh: ' : 'Unable to execute: ') + this.cmd.exec);
-          this.buildView.append(/\s/.test(this.cmd.exec) ? '`cmd` cannot contain space. Use `args` for arguments.' : '');
-        }.bind(this));
-
         this.child.on('close', function(exitCode) {
           this.buildView.buildFinished(0 === exitCode);
           if (0 === exitCode) {
+            // if the command has a linter, clear lints for successful builds.
+            if (this.cmd.linter != undefined) {
+                this.cmd.linter.setLinter(this.linter);
+                this.cmd.linter.clearLint();
+            }
             GoogleAnalytics.sendEvent('build', 'succeeded');
             this.finishedTimer = setTimeout(function() {
               this.buildView.detach();
             }.bind(this), 1000);
           } else {
-            var t = this.targets[this.activeTarget];
-            this.errorMatcher.set(t.errorMatch, this.replace(t.cwd), Buffer.concat([ this.stdout, this.stderr ]).toString('utf8'));
+            // if the command has a linter, send output buffers to linter helper.
+            if (this.cmd.linter != undefined) {
+                this.cmd.linter.setLinter(this.linter);
+                this.cmd.linter.updateLint(Buffer.concat([ this.stdout, this.stderr ]).toString('utf8'), this.cmd.errorMatch);
+            }
+            this.errorMatcher.set(this.cmd.errorMatch, this.replace(this.cmd.cwd), Buffer.concat([ this.stdout, this.stderr ]).toString('utf8'));
             if (atom.config.get('build.scrollOnError')) {
               this.errorMatcher.matchFirst();
             }

--- a/lib/tools/Cargo.js
+++ b/lib/tools/Cargo.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var fs = require('fs');
+var LintHelper = require('./linthelper');
 
 module.exports.niceName = 'Cargo';
 
@@ -14,20 +15,23 @@ module.exports.settings = function (path) {
     exec: 'cargo',
     args: [ 'build' ],
     sh: false,
-    errorMatch: '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):'
+    errorMatch: '(?<file>.+):(?<line>\\d+):(?<col>\\d+):\\s*(?<endline>\\d+):(?<endcol>\\d+)\\s+((?<error>error|fatal error)|(?<warning>warning)|(?<info>note)):\\s+(?<message>.+)\n',
+    linter: new LintHelper()
   },
   {
     name: 'Cargo: test',
     exec: 'cargo',
     args: [ 'test' ],
     sh: false,
-    errorMatch: '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):'
+    errorMatch: '(?<file>.+):(?<line>\\d+):(?<col>\\d+):\\s*(?<endline>\\d+):(?<endcol>\\d+)\\s+((?<error>error|fatal error)|(?<warning>warning)|(?<info>note)):\\s+(?<message>.+)\n',
+    linter: new LintHelper()
   },
   {
     name: 'Cargo: run',
     exec: 'cargo',
     args: [ 'run' ],
     sh: false,
-    errorMatch: '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):'
+    errorMatch: '(?<file>.+):(?<line>\\d+):(?<col>\\d+):\\s*(?<endline>\\d+):(?<endcol>\\d+)\\s+((?<error>error|fatal error)|(?<warning>warning)|(?<info>note)):\\s+(?<message>.+)\n',
+    linter: new LintHelper()
   }];
 };

--- a/lib/tools/linthelper.js
+++ b/lib/tools/linthelper.js
@@ -1,4 +1,4 @@
-'use strict'
+'use strict';
 
 var XRegExp = require('xregexp').XRegExp;
 var Atom = require('atom');
@@ -8,8 +8,8 @@ module.exports = (function () {
         this.linter;
         this.output;
         this.messageColour = {
-            error: "color:rgb(200, 0, 0)",
-            warning: "color:rgb(0, 148, 255)"
+            error: 'color:rgb(200, 0, 0)',
+            warning: 'color:rgb(0, 148, 255)'
         };
         // Rust-specific linting config.
         this.linterRustConfig = {
@@ -30,20 +30,19 @@ module.exports = (function () {
         this.matches = XRegExp.forEach(this.output, this.regex, function (match) {
           this.push(match);
         }, []);
-        var that = this;
+
         this.matches.map(function(err) {
             var type = (err.error ? err.error : err.warning);
             // console.log("Rust error type: " + type);
-            if (type != undefined) {
-                var htmlTag =  "<span class=\"badge badge-flexible\" style=\"color:rgb(0, 148, 255)\"> RS </span> " + err.message;
-                // var htmlTag =  "<span class=\"badge badge-flexible\" style=\"" + that.messageColour[type] + "\"> RS </span> " + err.message;
+            if (type !== undefined) {
+                var htmlTag =  '<span class=\"badge badge-flexible\" style=\"color:rgb(0, 148, 255)\"> RS </span> ' + err.message;
                 var projectPaths = atom.project.getPaths();
-                var projPath = projectPaths[0]; /// how to handle when more than one is returned?
+                var projPath = projectPaths[0]; /// TODO! how to handle when more than one is returned?
                 var errorOut = {
                     type: type,
                     text: err.message,
                     html: htmlTag,
-                    filePath: projPath+"\\"+err.file,
+                    filePath: projPath+'\\'+err.file,
                     range: new Atom.Range(new Atom.Point(parseInt(err.line-1), parseInt(err.col-1)), new Atom.Point(parseInt(err.endline-1), parseInt(err.endcol-1))),
                 };
                 this.push(errorOut);

--- a/lib/tools/linthelper.js
+++ b/lib/tools/linthelper.js
@@ -1,0 +1,61 @@
+'use strict'
+
+var XRegExp = require('xregexp').XRegExp;
+var Atom = require('atom');
+
+module.exports = (function () {
+    function LintHelper() {
+        this.linter;
+        this.output;
+        this.messageColour = {
+            error: "color:rgb(200, 0, 0)",
+            warning: "color:rgb(0, 148, 255)"
+        };
+        // Rust-specific linting config.
+        this.linterRustConfig = {
+            grammarScopes: ['source.rs'],
+            scope: 'project',
+            lintOnFly: false
+        };
+        this.linterErrors = [];
+    }
+    LintHelper.prototype.setLinter = function(linter) {
+        this.linter = linter;
+    };
+    LintHelper.prototype.updateLint = function (output, regex) {
+        this.matches = [];
+        this.linterErrors = [];
+        this.output = output;
+        this.regex = XRegExp(regex);
+        this.matches = XRegExp.forEach(this.output, this.regex, function (match) {
+          this.push(match);
+        }, []);
+        var that = this;
+        this.matches.map(function(err) {
+            var type = (err.error ? err.error : err.warning);
+            // console.log("Rust error type: " + type);
+            if (type != undefined) {
+                var htmlTag =  "<span class=\"badge badge-flexible\" style=\"color:rgb(0, 148, 255)\"> RS </span> " + err.message;
+                // var htmlTag =  "<span class=\"badge badge-flexible\" style=\"" + that.messageColour[type] + "\"> RS </span> " + err.message;
+                var projectPaths = atom.project.getPaths();
+                var projPath = projectPaths[0]; /// how to handle when more than one is returned?
+                var errorOut = {
+                    type: type,
+                    text: err.message,
+                    html: htmlTag,
+                    filePath: projPath+"\\"+err.file,
+                    range: new Atom.Range(new Atom.Point(parseInt(err.line-1), parseInt(err.col-1)), new Atom.Point(parseInt(err.endline-1), parseInt(err.endcol-1))),
+                };
+                this.push(errorOut);
+            }
+        }, this.linterErrors);
+        this.linter.deleteProjectMessages(this.linterRustConfig);
+        this.linter.setProjectMessages(this.linterRustConfig, this.linterErrors);
+        this.linter.views.render();
+    };
+    LintHelper.prototype.clearLint = function() {
+        this.linter.deleteProjectMessages(this.linterRustConfig);
+        this.linter.views.render();
+    };
+    return LintHelper;
+})();

--- a/package.json
+++ b/package.json
@@ -8,6 +8,13 @@
   "engines": {
     "atom": ">=0.50.0"
   },
+  "consumedServices": {
+    "linter-plus-self": {
+      "versions": {
+        "0.1.0": "consumeLinter"
+      }
+    }
+  },
   "dependencies": {
     "lodash": "^3.8.0",
     "bluebird": "^2.9.25",


### PR DESCRIPTION
I added support for pushing errors/warnings to Atom's Linter package, currently only for the Rust extension. I created a _linthelper.js_ class under tools, which can handle parsing the regex and building an array of Linter-complaint objects, and pushing them to that package.

I added a _linter_ property to your extension settings (currently only in the _Cargo.js_ one), which is then queries in the _build.js_ whenever a build is requested, and if it exists it updates the lint. 

I'm not sure if it covers all bases, but anyway, let me know if you think this is something that could be merged!