### PR TITLE
rust + cargo: Match failing testcases

### DIFF
--- a/lib/tools/Cargo.js
+++ b/lib/tools/Cargo.js
@@ -14,20 +14,20 @@ module.exports.settings = function (path) {
     exec: 'cargo',
     args: [ 'build' ],
     sh: false,
-    errorMatch: '(?<file>[^\\.]+.rs):(?<line>\\d+):(?<col>\\d+):'
+    errorMatch: '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):'
   },
   {
     name: 'Cargo: test',
     exec: 'cargo',
     args: [ 'test' ],
     sh: false,
-    errorMatch: '(?<file>[^\\.]+.rs):(?<line>\\d+):(?<col>\\d+):|thread \'[^\\\']+\' panicked at \'[^\\\']+\', (?<file>[^\\/][^\\:]+):(?<line>\\d+)'
+    errorMatch: '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):|thread \'[^\\\']+\' panicked at \'[^\\\']+\', (?<file>[^\\/][^\\:]+):(?<line>\\d+)'
   },
   {
     name: 'Cargo: run',
     exec: 'cargo',
     args: [ 'run' ],
     sh: false,
-    errorMatch: '(?<file>[^\\.]+.rs):(?<line>\\d+):(?<col>\\d+):'
+    errorMatch: '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):'
   }];
 };

--- a/lib/tools/Cargo.js
+++ b/lib/tools/Cargo.js
@@ -21,7 +21,10 @@ module.exports.settings = function (path) {
     exec: 'cargo',
     args: [ 'test' ],
     sh: false,
-    errorMatch: '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):|thread \'[^\\\']+\' panicked at \'[^\\\']+\', (?<file>[^\\/][^\\:]+):(?<line>\\d+)'
+    errorMatch: [
+      '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):',
+      'thread \'[^\\\']+\' panicked at \'[^\\\']+\', (?<file>[^\\/][^\\:]+):(?<line>\\d+)'
+    ]
   },
   {
     name: 'Cargo: run',

--- a/lib/tools/Cargo.js
+++ b/lib/tools/Cargo.js
@@ -14,20 +14,20 @@ module.exports.settings = function (path) {
     exec: 'cargo',
     args: [ 'build' ],
     sh: false,
-    errorMatch: '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):'
+    errorMatch: '(?<file>[^\\.]+.rs):(?<line>\\d+):(?<col>\\d+):'
   },
   {
     name: 'Cargo: test',
     exec: 'cargo',
     args: [ 'test' ],
     sh: false,
-    errorMatch: '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):'
+    errorMatch: '(?<file>[^\\.]+.rs):(?<line>\\d+):(?<col>\\d+):|thread \'[^\\\']+\' panicked at \'[^\\\']+\', (?<file>[^\\/][^\\:]+):(?<line>\\d+)'
   },
   {
     name: 'Cargo: run',
     exec: 'cargo',
     args: [ 'run' ],
     sh: false,
-    errorMatch: '(?<file>.+.rs):(?<line>\\d+):(?<col>\\d+):'
+    errorMatch: '(?<file>[^\\.]+.rs):(?<line>\\d+):(?<col>\\d+):'
   }];
 };


### PR DESCRIPTION
It should only match if a test 'panicked' in local code (e.g. via macro panic!, assert!, assert_eq!, unreachable!, unimplemented!, etc.) but not if the error occurred in the std-library (like Err(()).unwrap());

The distinction is done by only matching *relative* paths (not sure if this is 100% accurate - but working for me).

```rust
#[test]
pub fn A() {
    unimplemented!(); // matched
    // thread '...' panicked at 'not yet implemented', relative/path/to/my/file.rs:123
}

#[test]
pub fn B() {
    assert!(false); // matched
    // thread '...' panicked at 'assertion failed: false', relative/path/to/my/file.rs:123
}

#[test]
pub fn C() {
    let x : Result<(),()> = Err(());
    x.unwrap(); // *not* matched
    // thread '...' panicked at 'called `Result::unwrap()` on an `Err` value: ()', /home/rustbuild/src/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libcore/result.rs:729
}
```