### PR TITLE
Use a service instead of hard-coding all the tools.

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -13,6 +13,7 @@ var BuildView = require('./build-view');
 var GoogleAnalytics = require('./google-analytics');
 var ErrorMatcher = require('./error-matcher');
 var tools = require('./tools');
+var extra_tools = [];
 
 function BuildError(name, message) {
   this.name = name;
@@ -185,7 +186,7 @@ module.exports = {
           throw new BuildError('No active project', 'No project is active, don\'t know what to build...');
         }
 
-        return _.filter(tools, function (tool) {
+        return _.filter(tools.concat(extra_tools), function (tool) {
           return tool.isEligable(path);
         });
       })
@@ -437,5 +438,14 @@ module.exports = {
     } else {
       this.buildView.reset();
     }
+  },
+
+  consumeBuilder: function (builders) {
+    if (!(builders instanceof Array)) {
+      builders = [builders];
+    }
+    builders.forEach(function (builder) {
+      extra_tools.push(builder);
+    });
   }
 };

--- a/lib/build.js
+++ b/lib/build.js
@@ -6,6 +6,7 @@ var fs = Promise.promisifyAll(require('fs'));
 var path = require('path');
 var _ = require('lodash');
 var Promise = require('bluebird');
+var Disposable = require('atom').Disposable;
 
 var SaveConfirmView = require('./save-confirm-view');
 var TargetsView = require('./targets-view');
@@ -444,8 +445,9 @@ module.exports = {
     if (!(builders instanceof Array)) {
       builders = [builders];
     }
-    builders.forEach(function (builder) {
-      extra_tools.push(builder);
+    extra_tools = _.union(extra_tools, builders);
+    return new Disposable(function () {
+      extra_tools = _.difference(extra_tools, builders);
     });
   }
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,13 @@
     "jshint": "^2.5.11",
     "jscs": "^1.9.0"
   },
+  "consumedServices": {
+    "builder": {
+      "versions": {
+        "^1.0.0": "consumeBuilder"
+      }
+    }
+  },
   "scripts": {
     "test": "./node_modules/.bin/jscs lib/*.js spec/*.js && ./node_modules/.bin/jshint lib/*.js spec/*.js"
   },


### PR DESCRIPTION
It ended up being pretty easy to use a Service-based architecture, and I had some free time, so I did this.  :smile:

See https://github.com/bwinton/atom-build-jpm or https://github.com/bwinton/atom-build-markdown for example service providers.