### PR TITLE
Comparison was somehow case sensitive?

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -153,7 +153,7 @@ module.exports = {
       /* otherwise, build the one in the root of the active editor */
       return _.find(atom.project.getPaths(), function (path) {
         var realpath = fs.realpathSync(path);
-        return textEditor.getPath().substr(0, realpath.length) === realpath;
+        return textEditor.getPath().substr(0, realpath.length).toLowerCase() === realpath.toLowerCase();
       });
     }
   },


### PR DESCRIPTION
Got BuildError "No active project" because path wasn't matched correctly.
Narrowed it down to being a case sensitive comparison.

Left side of the comparison was "C:\temp\file.js" while right was "c:\temp\file.js" so just different case on the drive letter.

This small change fixed the problem.