### PR TITLE
[Bugfix] Parse on errorMatcher.set / handle no errorMatcher correctly

### DIFF
--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -209,6 +209,7 @@ module.exports = (function() {
     this.output.find('a').on('click', function() {
       onclick($(this).attr('id'));
     });
+    this.output.scrollTop(this.output[0].scrollHeight);
   };
 
   BuildView.prototype.scrollTo = function(type, id) {

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -190,7 +190,6 @@ module.exports = (function() {
     this.output.find('a').on('click', function() {
       onclick($(this).attr('id'));
     });
-    this.output.scrollTop(this.output[0].scrollHeight);
   };
 
   BuildView.prototype.scrollTo = function(type, id) {

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -24,6 +24,10 @@ module.exports = (function () {
   util.inherits(ErrorMatcher, EventEmitter);
 
   ErrorMatcher.prototype._gotoNext = function () {
+    if (0 === this.currentMatch.length) {
+      return;
+    }
+
     this._goto(this.currentMatch[0].id);
     this.currentMatch.push(this.currentMatch.shift());
   };
@@ -86,6 +90,8 @@ module.exports = (function () {
     this.cwd = cwd;
     this.output = output;
     this.currentMatch = [];
+
+    this._parse();
   };
 
   ErrorMatcher.prototype.match = function () {
@@ -94,10 +100,6 @@ module.exports = (function () {
     }
 
     GoogleAnalytics.sendEvent('errorMatch', 'match');
-
-    if (0 === this.currentMatch.length && 0 === this._parse()) {
-      return;
-    }
 
     this._gotoNext();
   };
@@ -108,10 +110,6 @@ module.exports = (function () {
     }
 
     GoogleAnalytics.sendEvent('errorMatch', 'first');
-
-    if (0 === this._parse()) {
-      return;
-    }
 
     this._gotoNext();
   };

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -36,7 +36,7 @@ module.exports = (function () {
   ErrorMatcher.prototype._goto = function (id) {
     var match = _.findWhere(this.currentMatch, { id: id });
     if (!match) {
-      throw new Error('Can\'t find match with id ' + id);
+      return this.emit('error', 'Can\'t find match with id ' + id);
     }
 
     // rotate to next match

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -16,6 +16,7 @@ module.exports = (function () {
     this.stdout = null;
     this.stderr = null;
     this.currentMatch = [];
+    this.firstMatchId = null;
 
     atom.commands.add('atom-workspace', 'build:error-match', this.match.bind(this));
     atom.commands.add('atom-workspace', 'build:error-match-first', this.matchFirst.bind(this));
@@ -29,11 +30,20 @@ module.exports = (function () {
     }
 
     this._goto(this.currentMatch[0].id);
-    this.currentMatch.push(this.currentMatch.shift());
   };
 
   ErrorMatcher.prototype._goto = function (id) {
     var match = _.findWhere(this.currentMatch, { id: id });
+    if (!match) {
+      throw new Error('Can\'t find match with id ' + id);
+    }
+
+    // rotate to next match
+    while (this.currentMatch[0] !== match) {
+      this.currentMatch.push(this.currentMatch.shift());
+    }
+    this.currentMatch.push(this.currentMatch.shift());
+
     if (!match.file) {
       return this.emit('error', 'Did not match any file. Don\'t know what to open.');
     }
@@ -68,6 +78,8 @@ module.exports = (function () {
       match.id = 'error-' + i;
       this.push(match);
     }, []);
+
+    this.firstMatchId = this.currentMatch[0].id;
 
     var output = '';
     var lastEnd = 0;
@@ -110,7 +122,9 @@ module.exports = (function () {
   ErrorMatcher.prototype.matchFirst = function () {
     GoogleAnalytics.sendEvent('errorMatch', 'first');
 
-    this._gotoNext();
+    if (this.firstMatchId) {
+      this._goto(this.firstMatchId);
+    }
   };
 
   return ErrorMatcher;

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -59,6 +59,10 @@ module.exports = (function () {
   };
 
   ErrorMatcher.prototype._parse = function () {
+    if (!this.regex) {
+      return;
+    }
+
     this.currentMatch = XRegExp.forEach(this.output, this.regex, function (match, i) {
       match.type = 'error';
       match.id = 'error-' + i;
@@ -77,12 +81,15 @@ module.exports = (function () {
     output += _.escape(this.output.substr(lastEnd));
 
     this.emit('replace', output, this._goto.bind(this));
-    return this.currentMatch.length;
   };
 
   ErrorMatcher.prototype.set = function (regex, cwd, output) {
     try {
-      this.regex = XRegExp(regex);
+      if (!regex) {
+        this.regex = null;
+      } else {
+        this.regex = XRegExp(regex);
+      }
     } catch (err) {
       this.regex = null;
       return this.emit('error', 'Error parsing regex:\n' + err);
@@ -95,20 +102,12 @@ module.exports = (function () {
   };
 
   ErrorMatcher.prototype.match = function () {
-    if (!this.regex) {
-      return;
-    }
-
     GoogleAnalytics.sendEvent('errorMatch', 'match');
 
     this._gotoNext();
   };
 
   ErrorMatcher.prototype.matchFirst = function () {
-    if (!this.regex) {
-      return;
-    }
-
     GoogleAnalytics.sendEvent('errorMatch', 'first');
 
     this._gotoNext();


### PR DESCRIPTION
This PR fixes two bugs:
 - Errors are now highlighted, when the build is finished, not when the user goes to the first error
 - no error matching is performed, when no errorMatcher is set