### PR TITLE
Updated error matching in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,14 +102,14 @@ the output of your build command and opens the correct file, row and column of
 the error. For instance:
 
 ```bash
-a.c:4:26: error: expected ';' after expression
+../foo/bar/a.c:4:26: error: expected ';' after expression
   printf("hello world\n")
                          ^
                          ;
 1 error generated.
 ```
 
-Would be matched with the regular expression: `^(?<file>[^\\.]+.c):(?<line>\\d+):(?<col>\\d+)`.
+Would be matched with the regular expression: `\^(?<file>[\\/0-9a-zA-Z\\._]+):(?<line>\\d+):(?<col>\\d+)`.
 After the build has failed, pressing `cmd-alt-g` (OS X) or `ctrl-alt-g` (Linux/Windows), `a.c` would be
 opened and the cursor would be placed at row 4, column 26.
 


### PR DESCRIPTION
Hello,

I changed the regex to a more flexible one that handles the full path.
Also I had to escape the ^ to make it functional.