### PR TITLE
Option to customize output panel font size added.

### DIFF
--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -23,6 +23,7 @@ module.exports = (function() {
     atom.config.observe('build.panelVisibility', this.visibleFromConfig.bind(this));
     atom.config.observe('build.monocleHeight', this.heightFromConfig.bind(this));
     atom.config.observe('build.minimizedHeight', this.heightFromConfig.bind(this));
+    atom.config.observe('build.output.fontSize', this.outputFontSizeFromConfig.bind(this));
 
     atom.commands.add('atom-workspace', 'build:toggle-panel', this.toggle.bind(this));
   }
@@ -63,6 +64,7 @@ module.exports = (function() {
     this.panel = atom.workspace.addBottomPanel({ item: this });
     this.height = this.output.offset().top + this.output.height();
     this.heightFromConfig();
+    this.outputFontSizeFromConfig();
   };
 
   BuildView.prototype.detach = function(force) {
@@ -87,6 +89,10 @@ module.exports = (function() {
       this.setHeightPercent(atom.config.get('build.minimizedHeight'));
     }
   };
+
+  BuildView.prototype.outputFontSizeFromConfig = function() {
+    this.output.css('font-size', atom.config.get('build.output.fontSize') + 'px');
+  }
 
   BuildView.prototype.visibleFromConfig = function(val) {
     switch (val) {

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -92,7 +92,7 @@ module.exports = (function() {
 
   BuildView.prototype.outputFontSizeFromConfig = function() {
     this.output.css('font-size', atom.config.get('build.output.fontSize') + 'px');
-  }
+  };
 
   BuildView.prototype.visibleFromConfig = function(val) {
     switch (val) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -81,6 +81,20 @@ module.exports = {
       minimum: 0.1,
       maximum: 0.9,
       order: 7
+    },
+    output: {
+        type: 'object',
+        properties: {
+            fontSize: {
+                title: 'Build Output Font Size',
+                description: 'Font size in the build panel',
+                type: 'number',
+                default: 15,
+                minimum: 5,
+                maximum: 50,
+                order: 8
+            }
+        }
     }
   },
 


### PR DESCRIPTION
Default font size in the build output panel is not customizable. This is very annoying when working from small screens e.g. 14 inch. Font is very small and very hard to read. While font in the main editor area can be customized. This should be fixed.