### PR TITLE
[Bugfix] Not all windows programs use \r\n as line ending

### DIFF
--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -193,7 +193,7 @@ module.exports = (function() {
 
     this.buffer = Buffer.concat([ this.buffer, data ]);
     var bufferedString = this.buffer.toString();
-    if (0 === bufferedString.length || (!force && -1 === bufferedString.indexOf(require('os').EOL))) {
+    if (0 === bufferedString.length || (!force && -1 === bufferedString.indexOf('\n'))) {
       /* No line break in output or no output at all. Don't do anything */
       return;
     }


### PR DESCRIPTION
Some programs in windows only use \n as newline, e. g. coffee. Without this fix, the output of such a program is only displayed, when it has finished running. Since both \r\n and \n end with \n, this fix should not cause problems.