### PR TITLE
[Bugfix] Don't insert additional newlines

### DIFF
--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -186,7 +186,7 @@ module.exports = (function() {
     this.titleText.text('Aborted!');
   };
 
-  BuildView.prototype.append = function(data, force) {
+  BuildView.prototype.append = function(data) {
     this.outputContent.append(this.a2h.toHtml(_.escape(data)));
     this.output.scrollTop(this.output[0].scrollHeight);
   };

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -19,7 +19,6 @@ module.exports = (function() {
     };
     this.a2h = new Convert();
     this.monocle = false;
-    this.buffer = new Buffer(0);
     this.starttime = new Date();
 
     atom.config.observe('build.panelVisibility', this.visibleFromConfig.bind(this));
@@ -41,7 +40,9 @@ module.exports = (function() {
       });
 
       BuildView.div(function() {
-        BuildView.ol({ class: 'output panel-body', outlet: 'output' });
+        BuildView.ol({ class: 'output panel-body', outlet: 'output' }, function() {
+          BuildView.li({ outlet: 'outputContent' });
+        });
       });
 
       BuildView.div(function() {
@@ -108,7 +109,7 @@ module.exports = (function() {
     clearTimeout(this.titleTimer);
     this.titleTimer = 0;
     this.title.removeClass('success error warning');
-    this.output.empty();
+    this.outputContent.empty();
     this.titleText.text('Cleared.');
     this.detach();
   };
@@ -172,7 +173,6 @@ module.exports = (function() {
     }
     this.titleText.text(success ? 'Build finished.' : 'Build failed.');
     this.title.addClass(success ? 'success' : 'error');
-    this.append(new Buffer(0), true);
     clearTimeout(this.titleTimer);
   };
 
@@ -184,28 +184,16 @@ module.exports = (function() {
 
   BuildView.prototype.buildAborted = function() {
     this.titleText.text('Aborted!');
-    this.append(new Buffer(0), true);
   };
 
   BuildView.prototype.append = function(data, force) {
-    data = Buffer.isBuffer(data) ? data : new Buffer(data);
-    force = force || false;
-
-    this.buffer = Buffer.concat([ this.buffer, data ]);
-    var bufferedString = this.buffer.toString();
-    if (0 === bufferedString.length || (!force && -1 === bufferedString.indexOf('\n'))) {
-      /* No line break in output or no output at all. Don't do anything */
-      return;
-    }
-
-    this.buffer = new Buffer(0);
-    this.output.append('<li>' + this.a2h.toHtml(_.escape(bufferedString)) + '</li>');
+    this.outputContent.append(this.a2h.toHtml(_.escape(data)));
     this.output.scrollTop(this.output[0].scrollHeight);
   };
 
   BuildView.prototype.replace = function(text, onclick) {
-    this.output.empty();
-    this.output.append('<li>' + (this.a2h.toHtml(text)) + '</li>');
+    this.outputContent.empty();
+    this.outputContent.append(this.a2h.toHtml(text));
     this.output.find('a').on('click', function() {
       onclick($(this).attr('id'));
     });

--- a/spec/build-view-spec.js
+++ b/spec/build-view-spec.js
@@ -89,10 +89,12 @@ describe('Visible', function() {
       });
 
       runs(function () {
-        /* Now we expect one line for the 'Executing...' row. And one for the actual output. */
         var el = workspaceElement.querySelector('.build .output');
-        expect(el.childElementCount).toEqual(2);
-        expect(el.querySelector('li:nth-child(2)').textContent).toEqual('same line\n');
+        expect(el.childElementCount).toEqual(1);
+        /* Now we expect one line for the 'Executing...' row, one for the actual output and an empty one at the end. */
+        var lines = el.querySelector('li').textContent.split('\n');
+        expect(lines.length).toEqual(3);
+        expect(lines[1]).toEqual('same line');
       });
     });
 


### PR DESCRIPTION
Code like the following could cause additional linebreaks in the build-window:
```coffeescript
process.stdout.write("same line\nsame");
setTimeout (-> process.stdout.write("line\n")), 1000
```
This PR fixes this bug, by removing the buffer and simply appending to the first `li` in the output instead of adding new `li`.