### PR TITLE
Changed source of name for target

### DIFF
--- a/lib/tools/atom-build.js
+++ b/lib/tools/atom-build.js
@@ -32,8 +32,8 @@ module.exports.settings = function (cwd) {
   var config = [];
 
   config.push(createBuildConfig(build, build.name || 'default'));
-  _.forEach(build.targets || [], function (target) {
-    config.push(createBuildConfig(target, target.name));
+  _.forEach(build.targets || [], function (target, name) {
+    config.push(createBuildConfig(target, target.name || name));
   });
 
   return config;

--- a/lib/tools/atom-build.js
+++ b/lib/tools/atom-build.js
@@ -32,8 +32,8 @@ module.exports.settings = function (cwd) {
   var config = [];
 
   config.push(createBuildConfig(build, build.name || 'default'));
-  _.forEach(build.targets || [], function (target, name) {
-    config.push(createBuildConfig(target, name));
+  _.forEach(build.targets || [], function (target) {
+    config.push(createBuildConfig(target, target.name));
   });
 
   return config;


### PR DESCRIPTION
It was grabbing an invalid value, now it follows how the
main command name is retrieved.

This fixes issue 164: https://github.com/noseglid/atom-build/issues/164