### PR TITLE
Build view interface

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -29,5 +29,6 @@
   "excludeFiles": [
     "node_modules/**",
     "spec/fixture/node_modules/**"
-  ]
+  ],
+  "esnext": true
 }

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -204,6 +204,11 @@ module.exports = (function() {
   };
 
   BuildView.prototype.link = function(text, id, onClick) {
+    if (_.findWhere(this.links, { text: text })) {
+      /* This text already has a link to it. Ignore it. */
+      return;
+    }
+
     this.links.push({
       id: id,
       text: text,

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -3,7 +3,6 @@
 
 var _ = require('lodash');
 var View = require('atom-space-pen-views').View;
-var $ = require('atom-space-pen-views').$;
 var cscompatability = require('./cscompatability');
 var GoogleAnalytics = require('./google-analytics');
 var Convert = require('ansi-to-html');
@@ -20,6 +19,8 @@ module.exports = (function() {
     this.a2h = new Convert();
     this.monocle = false;
     this.starttime = new Date();
+    this.buffer = new Buffer(0);
+    this.links = [];
 
     atom.config.observe('build.panelVisibility', this.visibleFromConfig.bind(this));
     atom.config.observe('build.monocleHeight', this.heightFromConfig.bind(this));
@@ -103,6 +104,8 @@ module.exports = (function() {
 
   BuildView.prototype.reset = function() {
     clearTimeout(this.titleTimer);
+    this.buffer = new Buffer(0);
+    this.links = [];
     this.titleTimer = 0;
     this.title.removeClass('success error warning');
     this.output.empty();
@@ -182,22 +185,35 @@ module.exports = (function() {
     this.titleText.text('Aborted!');
   };
 
-  BuildView.prototype.append = function(data) {
-    this.output.append(this.a2h.toHtml(_.escape(data)));
-    this.output.scrollTop(this.output[0].scrollHeight);
-  };
-
-  BuildView.prototype.replace = function(text, onclick) {
-    this.output.empty();
-    this.output.append(this.a2h.toHtml(text));
-    this.output.find('a').on('click', function() {
-      onclick($(this).attr('id'));
+  BuildView.prototype._render = function() {
+    var string = this.a2h.toHtml(_.escape(this.buffer.toString('utf8')));
+    _.forEach(this.links, function (link, index) {
+      string = string.replace(link.text, '<a id="' + link.id + '">' + _.escape(link.text) + '</a>');
     });
+    this.output.html(string);
+    this.output.find('a').on('click', (event) => {
+      var link = _.findWhere(this.links, { id: event.currentTarget.id });
+      link.onClick();
+    });
+  };
+
+  BuildView.prototype.append = function(data) {
+    this.buffer = Buffer.concat([ this.buffer, Buffer.isBuffer(data) ? data : new Buffer(data) ]);
+    this._render();
     this.output.scrollTop(this.output[0].scrollHeight);
   };
 
-  BuildView.prototype.scrollTo = function(type, id) {
-    var position = this.output.find('.' + type + '#' + id).position();
+  BuildView.prototype.link = function(text, id, onClick) {
+    this.links.push({
+      id: id,
+      text: text,
+      onClick: onClick
+    });
+    this._render();
+  };
+
+  BuildView.prototype.scrollTo = function(id) {
+    var position = this.output.find('#' + id).position();
     if (position) {
       this.output.scrollTop(position.top + this.output.scrollTop());
     }

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -3,9 +3,9 @@
 
 var _ = require('lodash');
 var View = require('atom-space-pen-views').View;
+var ansi_up = require('ansi_up');
 var cscompatability = require('./cscompatability');
 var GoogleAnalytics = require('./google-analytics');
-var Convert = require('ansi-to-html');
 
 module.exports = (function() {
   function BuildView() {
@@ -16,7 +16,6 @@ module.exports = (function() {
       this.n = this.n || 0;
       (++this.n === 3) && this.push(this.shift()) && (this.n = 0);
     };
-    this.a2h = new Convert();
     this.monocle = false;
     this.starttime = new Date();
     this.buffer = new Buffer(0);
@@ -186,11 +185,12 @@ module.exports = (function() {
   };
 
   BuildView.prototype._render = function() {
-    var string = this.a2h.toHtml(_.escape(this.buffer.toString('utf8')));
+    var string = _.escape(this.buffer.toString('utf8'));
     _.forEach(this.links, function (link, index) {
-      string = string.replace(link.text, '<a id="' + link.id + '">' + _.escape(link.text) + '</a>');
+      var replaceRegex = new RegExp(_.escape(link.text), 'g');
+      string = string.replace(replaceRegex, '<a id="' + link.id + '">' + _.escape(link.text) + '</a>');
     });
-    this.output.html(string);
+    this.output.html(ansi_up.ansi_to_html(string));
     this.output.find('a').on('click', (event) => {
       var link = _.findWhere(this.links, { id: event.currentTarget.id });
       link.onClick();

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -187,7 +187,7 @@ module.exports = (function() {
   BuildView.prototype._render = function() {
     var string = _.escape(this.buffer.toString('utf8'));
     _.forEach(this.links, function (link, index) {
-      var replaceRegex = new RegExp(_.escape(link.text), 'g');
+      var replaceRegex = new RegExp(_.escapeRegExp(link.text), 'g');
       string = string.replace(replaceRegex, '<a id="' + link.id + '">' + _.escape(link.text) + '</a>');
     });
     this.output.html(ansi_up.ansi_to_html(string));

--- a/lib/build.js
+++ b/lib/build.js
@@ -123,8 +123,14 @@ module.exports = {
       atom.notifications.addError('Error matching failed!', { detail: message });
     });
 
-    this.errorMatcher.on('scroll', this.buildView.scrollTo.bind(this.buildView));
-    this.errorMatcher.on('replace', this.buildView.replace.bind(this.buildView));
+    this.errorMatcher.on('matched', (id) => {
+      this.buildView.scrollTo(id);
+    });
+
+    this.errorMatcher.on('match', (text, id) => {
+      var callback = this.errorMatcher.goto.bind(this.errorMatcher, id);
+      this.buildView.link(text, id, callback);
+    });
 
     this.refreshTargets().catch(function(e) {});
   },

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -30,10 +30,10 @@ module.exports = (function () {
       return;
     }
 
-    this._goto(this.currentMatch[0].id);
+    this.goto(this.currentMatch[0].id);
   };
 
-  ErrorMatcher.prototype._goto = function (id) {
+  ErrorMatcher.prototype.goto = function (id) {
     var match = _.findWhere(this.currentMatch, { id: id });
     if (!match) {
       return this.emit('error', 'Can\'t find match with id ' + id);
@@ -65,15 +65,14 @@ module.exports = (function () {
         initialColumn: col,
         searchAllPanes: true
       });
-      this.emit('scroll', match.type, match.id);
+      this.emit('matched', match.id);
     }.bind(this));
   };
 
   ErrorMatcher.prototype._parse = function () {
     this.currentMatch = [];
     var matchFunction = function (match, i) {
-      match.type = 'error';
-      match.id = 'error-' + regexIndex + '-' + i;
+      match.id = 'error-match-' + regexIndex + '-' + i;
       this.push(match);
     };
     for (var regexIndex in this.regex) {
@@ -86,23 +85,9 @@ module.exports = (function () {
 
     this.firstMatchId = (this.currentMatch.length > 0) ? this.currentMatch[0].id : null;
 
-    var output = '';
-    var lastEnd = 0;
-    for (var matchIndex in this.currentMatch) {
-      var match = this.currentMatch[matchIndex];
-
-      if (match.index < lastEnd) {
-        // overlapping matches, only highlight first
-        continue;
-      }
-
-      output += _.escape(this.output.substr(lastEnd, match.index - lastEnd));
-      output += util.format('<a class="%s" id="%s">%s</a>', match.type, match.id, _.escape(match[0]));
-      lastEnd = match.index + match[0].length;
-    }
-    output += _.escape(this.output.substr(lastEnd));
-
-    this.emit('replace', output, this._goto.bind(this));
+    _.forEach(this.currentMatch, (match, index) => {
+      this.emit('match', match[0], match.id);
+    });
   };
 
   ErrorMatcher.prototype.set = function (regex, cwd, output) {
@@ -137,7 +122,7 @@ module.exports = (function () {
     GoogleAnalytics.sendEvent('errorMatch', 'first');
 
     if (this.firstMatchId) {
-      this._goto(this.firstMatchId);
+      this.goto(this.firstMatchId);
     }
   };
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "atom": ">=0.50.0"
   },
   "dependencies": {
-    "ansi-to-html": "^0.3.0",
+    "ansi_up": "^1.3.0",
     "atom-space-pen-views": "^2.0.3",
     "fs-extra": "^0.23.0",
     "getmac": "^1.0.7",

--- a/spec/build-error-match-spec.js
+++ b/spec/build-error-match-spec.js
@@ -45,6 +45,32 @@ describe('Error Match', function() {
     fs.removeSync(directory);
   });
 
+  describe('when error matcher is configured incorrectly', function () {
+    it('should show an error if regex is invalid', function () {
+
+      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
+        cmd: 'return 1',
+        errorMatch: '(invalidRegex'
+      }));
+
+      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsFor(function() {
+        return workspaceElement.querySelector('.build .title') &&
+          workspaceElement.querySelector('.build .title').classList.contains('error');
+      });
+
+      runs(function() {
+        expect(atom.notifications.getNotifications().length).toEqual(1);
+
+        var notification = atom.notifications.getNotifications()[0];
+        expect(notification.getType()).toEqual('error');
+        expect(notification.getMessage()).toEqual('Error matching failed!');
+        expect(notification.options.detail).toMatch(/Unterminated group/);
+      });
+    });
+  });
+
   describe('when output is captured to show editor on error', function () {
     it('should place the line and column on error in correct file', function () {
       expect(workspaceElement.querySelector('.build')).not.toExist();
@@ -298,30 +324,6 @@ describe('Error Match', function() {
         expect(editor.getTitle()).toEqual('.atom-build.json');
         expect(bufferPosition.row).toEqual(2);
         expect(bufferPosition.column).toEqual(7);
-      });
-    });
-
-    it('should show an error if regex is invalid', function () {
-
-      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-        cmd: 'return 1',
-        errorMatch: '(invalidRegex'
-      }));
-
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
-
-      waitsFor(function() {
-        return workspaceElement.querySelector('.build .title') &&
-          workspaceElement.querySelector('.build .title').classList.contains('error');
-      });
-
-      runs(function() {
-        expect(atom.notifications.getNotifications().length).toEqual(1);
-
-        var notification = atom.notifications.getNotifications()[0];
-        expect(notification.getType()).toEqual('error');
-        expect(notification.getMessage()).toEqual('Error matching failed!');
-        expect(notification.options.detail).toMatch(/Unterminated group/);
       });
     });
 

--- a/spec/build-view-spec.js
+++ b/spec/build-view-spec.js
@@ -135,4 +135,29 @@ describe('Visible', function() {
       });
     });
   });
+
+  describe('when links are added', function () {
+    it('should only add one link per text, even if multiple is requested', function () {
+      expect(workspaceElement.querySelector('.build')).not.toExist();
+
+      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
+        cmd: 'echo match1 match1 match1 && exit 1',
+        errorMatch: 'match1'
+      }));
+      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsFor(function() {
+        return workspaceElement.querySelector('.build .title') &&
+          workspaceElement.querySelector('.build .title').classList.contains('error');
+      });
+
+      runs(function() {
+        var output = workspaceElement.querySelector('.build .output');
+        expect(output.children.length).toEqual(6);
+        for (var i = 0; i < output.children.length; i++) {
+          expect(output.children[i].id).toEqual('error-match-0-0');
+        }
+      });
+    });
+  });
 });

--- a/spec/build-view-spec.js
+++ b/spec/build-view-spec.js
@@ -57,7 +57,7 @@ describe('Visible', function() {
       });
 
       runs(function () {
-        expect(workspaceElement.querySelector('.build .output > span').style.color.match(/\d+/g)).toEqual([ '170', '0', '0' ]);
+        expect(workspaceElement.querySelector('.build .output > span').style.color.match(/\d+/g)).toEqual([ '187', '0', '0' ]);
       });
     });
 

--- a/styles/build.less
+++ b/styles/build.less
@@ -39,6 +39,10 @@
     list-style: none;
     font-family: monospace;
   }
+
+  a {
+    text-decoration: underline;
+  }
 }
 
 .btn-container {


### PR DESCRIPTION
The interfaces between `build`, `error-matcher` and `build-view`
is improved to decouple the modules. `error-matcher` no longer
have any knowledge of how the matching it performs is actually
used, and `build-view` no longer knows what the links it creates
are used for.

All together: better design.