### PR TITLE
Keymap specificity to not collide

### DIFF
--- a/keymaps/build.json
+++ b/keymaps/build.json
@@ -1,12 +1,12 @@
 {
-  ".platform-darwin atom-workspace": {
+  ".platform-darwin atom-workspace, .platform-darwin atom-text-editor": {
     "cmd-alt-b": "build:trigger",
     "cmd-alt-v": "build:toggle-panel",
     "cmd-alt-g": "build:error-match",
     "cmd-alt-h": "build:error-match-first",
     "cmd-alt-t": "build:select-active-target"
   },
-  ".platform-linux atom-workspace, .platform-win32 atom-workspace": {
+  ".platform-linux atom-workspace, .platform-linux atom-text-editor, .platform-win32 atom-workspace, .platform-win32 atom-text-editor": {
     "ctrl-alt-b": "build:trigger",
     "ctrl-alt-v": "build:toggle-panel",
     "ctrl-alt-g": "build:error-match",


### PR DESCRIPTION
On Linux, editor:move-to-previous-subword-boundary is bound
to `ctrl-alt-b`. Add specificity to the build keymap to win.

Fixes #168