### PR TITLE
ErrorMatcher: Defensive array loops

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -29,5 +29,6 @@
   "excludeFiles": [
     "node_modules/**",
     "spec/fixture/node_modules/**"
-  ]
+  ],
+  "esnext": true
 }

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -71,14 +71,15 @@ module.exports = (function () {
 
   ErrorMatcher.prototype._parse = function () {
     this.currentMatch = [];
-    var matchFunction = function (match, i) {
+    var self = this;
+    var matchFunction = function (match, i, string, regex) {
       match.type = 'error';
-      match.id = 'error-' + regexIndex + '-' + i;
+      match.id = 'error-' + self.regex.indexOf(regex) + '-' + i;
       this.push(match);
     };
-    for (var regexIndex in this.regex) {
-      XRegExp.forEach(this.output, this.regex[regexIndex], matchFunction, this.currentMatch);
-    }
+    this.regex.forEach((regex) => {
+      XRegExp.forEach(this.output, regex, matchFunction, this.currentMatch);
+    });
 
     this.currentMatch.sort(function(a, b) {
       return a.index - b.index;
@@ -88,9 +89,7 @@ module.exports = (function () {
 
     var output = '';
     var lastEnd = 0;
-    for (var matchIndex in this.currentMatch) {
-      var match = this.currentMatch[matchIndex];
-
+    for (let match of this.currentMatch) {
       if (match.index < lastEnd) {
         // overlapping matches, only highlight first
         continue;


### PR DESCRIPTION
Avoid enumerating potential extended properties on
the array prototype.

Fixes #173 