### PR TITLE
Fix example target JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ exactly what to execute. Create a file named `.atom-build.json` in your project 
       "errorMatch": [
         "^regexp1$",
         "^regexp2$"
-        ]
+      ],
       "keymap": "<keymap string>",
       "targets": {
         "<name of target>": {


### PR DESCRIPTION
The JSON wasn't valid in the example target due to a missing comma.