### PR TITLE
Added Warning about bundled tools removal

### DIFF
--- a/lib/tools/Cargo.js
+++ b/lib/tools/Cargo.js
@@ -10,6 +10,16 @@ module.exports.isEligable = function (path) {
 };
 
 module.exports.settings = function (path) {
+  if (!atom.config.get('deprecated.tool.cargo')) {
+    atom.notifications.addWarning('Bundled `Cargo` build will be removed', {
+      dismissable: true,
+      detail:
+        'You are using a bundled tool for `build` which will have to be installed seperately next version of `build`.\n' +
+        'You can install `build-cargo` (apm install build-cargo) at this time and you will be well prepared for the next release!'
+    });
+    atom.config.set('deprecated.tool.cargo', true);
+  }
+
   return [ {
     name: 'Cargo: build',
     exec: 'cargo',

--- a/lib/tools/Elixir.js
+++ b/lib/tools/Elixir.js
@@ -10,6 +10,16 @@ module.exports.isEligable = function (path) {
 };
 
 module.exports.settings = function (path) {
+  if (!atom.config.get('deprecated.tool.elixir')) {
+    atom.notifications.addWarning('Bundled `Elixir` build will be removed', {
+      dismissable: true,
+      detail:
+        'You are using a bundled tool for `build` which will have to be installed seperately next version of `build`.\n' +
+        'You can install `build-elixir` (apm install build-elixir) at this time and you will be well prepared for the next release!'
+    });
+    atom.config.set('deprecated.tool.elixir', true);
+  }
+
   return [ {
     name: 'Elixir: default',
     exec: 'mix',

--- a/lib/tools/Grunt.js
+++ b/lib/tools/Grunt.js
@@ -16,6 +16,16 @@ module.exports.isEligable = function (cwd) {
 };
 
 module.exports.settings = function (cwd) {
+  if (!atom.config.get('deprecated.tool.grunt')) {
+    atom.notifications.addWarning('Bundled `Grunt` build will be removed', {
+      dismissable: true,
+      detail:
+        'You are using a bundled tool for `build` which will have to be installed seperately next version of `build`.\n' +
+        'You can install `build-grunt` (apm install build-grunt) at this time and you will be well prepared for the next release!'
+    });
+    atom.config.set('deprecated.tool.grunt', true);
+  }
+
   var createConfig = function (name, args) {
     var executable = /^win/.test(process.platform) ? 'grunt.cmd' : 'grunt';
     var localPath = path.join(cwd, 'node_modules', '.bin', executable);

--- a/lib/tools/gulp.js
+++ b/lib/tools/gulp.js
@@ -17,6 +17,16 @@ module.exports.isEligable = function (cwd) {
 };
 
 module.exports.settings = function (cwd) {
+  if (!atom.config.get('deprecated.tool.gulp')) {
+    atom.notifications.addWarning('Bundled `gulp` build will be removed', {
+      dismissable: true,
+      detail:
+        'You are using a bundled tool for `build` which will have to be installed seperately next version of `build`.\n' +
+        'You can install `build-gulp` (apm install build-gulp) at this time and you will be well prepared for the next release!'
+    });
+    atom.config.set('deprecated.tool.gulp', true);
+  }
+
   var createConfig = function (name, args) {
     var executable = /^win/.test(process.platform) ? 'gulp.cmd' : 'gulp';
     var localPath = path.join(cwd, 'node_modules', '.bin', executable);

--- a/lib/tools/make.js
+++ b/lib/tools/make.js
@@ -11,6 +11,16 @@ module.exports.isEligable = function (cwd) {
 };
 
 module.exports.settings = function (cwd) {
+  if (!atom.config.get('deprecated.tool.make')) {
+    atom.notifications.addWarning('Bundled `make` build will be removed', {
+      dismissable: true,
+      detail:
+      'You are using a bundled tool for `build` which will have to be installed seperately next version of `build`.\n' +
+      'You can install `build-make` (apm install build-make) at this time and you will be well prepared for the next release!'
+    });
+    atom.config.set('deprecated.tool.make', true);
+  }
+
   return [ {
     name: 'GNU Make: default',
     exec: 'make',

--- a/lib/tools/npm_apm.js
+++ b/lib/tools/npm_apm.js
@@ -23,6 +23,16 @@ module.exports.isEligable = function (cwd) {
 };
 
 module.exports.settings = function (cwd) {
+  if (!atom.config.get('deprecated.tool.npmapm')) {
+    atom.notifications.addWarning('Bundled `npm` and `apm` build will be removed', {
+      dismissable: true,
+      detail:
+        'You are using a bundled tool for `build` which will have to be installed seperately next version of `build`.\n' +
+        'You can install `build-npm-apm` (apm install build-npm-apm) at this time and you will be well prepared for the next release!'
+    });
+    atom.config.set('deprecated.tool.npmapm', true);
+  }
+
   var realPackage = fs.realpathSync(path.join(cwd, 'package.json'));
   var pkg = require(realPackage);
 


### PR DESCRIPTION
Bundled tools will be removed in v0.48.0. As a preparation,
in v0.47.0 a warning will be included which urges the user
to install the stand-alone package. The warning will only
be shown once, and only if the tool is being used.