### PR TITLE
make targets available as atom commands

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -139,7 +139,11 @@ module.exports = {
       this.buildView.link(text, id, callback);
     });
 
-    this.refreshTargets().catch(function(e) {});
+    var _this = this;
+    var onInit = atom.packages.onDidActivateInitialPackages(function() {
+        _this.refreshTargets().catch(function(e) {});
+        onInit.dispose();
+    });
   },
 
   deactivate: function() {
@@ -236,19 +240,24 @@ module.exports = {
         });
 
         _.forEach(targets, function (target, targetName) {
-          if (!target.keymap) {
-            target.dispose = _.noop;
-            return;
+          var keymapDispose = null;
+          var commandName = 'build-' + targetName;
+          // there may be only one : in commandName
+          var m = targetName.match(/^(.*?):\s*(.*)/);
+          if (m) {
+              commandName = 'build-' + m[0] + ':' + targetName.replace(/:/g, '-');
+          }
+          commandName = commandName.replace(/\s+/, '-').replace(/-+/, '-');
+          if (target.keymap) {
+              GoogleAnalytics.sendEvent('keymap', 'registered', target.keymap);
+              var keymapSpec = { 'atom-workspace': {} };
+              keymapSpec['atom-workspace'][target.keymap] = commandName;
+              keymapDispose = atom.keymaps.add(targetName, keymapSpec);
           }
 
-          GoogleAnalytics.sendEvent('keymap', 'registered', target.keymap);
-          var commandName = 'build:trigger:' + targetName;
-          var keymapSpec = { 'atom-workspace': {} };
-          keymapSpec['atom-workspace'][target.keymap] = commandName;
-          var keymapDispose = atom.keymaps.add(targetName, keymapSpec);
-          var commandDispose = atom.commands.add('atom-workspace', commandName, this.build.bind(this, 'trigger'));
+          var commandDispose = atom.commands.add('atom-workspace', commandName, this.build.bind(this, targetName));
           target.dispose = function () {
-            keymapDispose.dispose();
+            if (keymapDispose) { keymapDispose.dispose(); }
             commandDispose.dispose();
           };
         }.bind(this));
@@ -316,7 +325,12 @@ module.exports = {
         return (this.activeTarget) ? this.targets : this.refreshTargets();
       }.bind(this))
       .then(function (targets) {
-        this.cmd = targets[targetName ? targetName : this.activeTarget];
+        if (targets[source]) {
+            this.cmd = targets[source];
+        } else {
+            this.cmd = targets[targetName ? targetName : this.activeTarget];
+        }
+
         GoogleAnalytics.sendEvent('build', 'triggered');
 
         if (!this.cmd.exec) {


### PR DESCRIPTION
I like to have targets available as normal atom commands.  Having e.g. build command "GNU Make: default", you can access it from command palette as "Build GNU Make: default".