### PR TITLE
Calling dialog commands without dialog

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -114,8 +114,10 @@ module.exports = {
       document.activeElement.click();
     });
     atom.commands.add('atom-workspace', 'build:no-confirm', function() {
-      GoogleAnalytics.sendEvent('build', 'not confirmed');
-      this.saveConfirmView.cancel();
+      if (this.saveConfirmView) {
+        GoogleAnalytics.sendEvent('build', 'not confirmed');
+        this.saveConfirmView.cancel();
+      }
     }.bind(this));
 
     atom.workspace.observeTextEditors(function(editor) {

--- a/spec/build-confirm-spec.js
+++ b/spec/build-confirm-spec.js
@@ -90,6 +90,11 @@ describe('Confirm', function() {
       });
     });
 
+    it('should not do anything if issuing no-confirm whithout the dialog', function () {
+      expect(workspaceElement.querySelector('.build-confirm')).not.toExist();
+      atom.commands.dispatch(workspaceElement, 'build:no-confirm');
+    });
+
     it('should not confirm if a TextEditor edits an unsaved file', function() {
       expect(workspaceElement.querySelector('.build-confirm')).not.toExist();
 


### PR DESCRIPTION
Make sure dialog exists before calling commands
on it.

Fixes #202