### PR TITLE
ErrorMatcher: Do not prepend cwd multiple times

### DIFF
--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -45,28 +45,29 @@ module.exports = (function () {
     }
     this.currentMatch.push(this.currentMatch.shift());
 
-    if (!match.file) {
+    let file = match.file;
+    if (!file) {
       return this.emit('error', 'Did not match any file. Don\'t know what to open.');
     }
 
-    if (!path.isAbsolute(match.file)) {
-      match.file = this.cwd + path.sep + match.file;
+    if (!path.isAbsolute(file)) {
+      file = this.cwd + path.sep + file;
     }
 
     var row = match.line ? match.line - 1 : 0; /* Because atom is zero-based */
     var col =  match.col ? match.col - 1 : 0; /* Because atom is zero-based */
 
-    fs.exists(match.file, function (exists) {
+    fs.exists(file, (exists) => {
       if (!exists) {
-        return this.emit('error', 'Matched file does not exist: ' + match.file);
+        return this.emit('error', 'Matched file does not exist: ' + file);
       }
-      atom.workspace.open(match.file, {
+      atom.workspace.open(file, {
         initialLine: row,
         initialColumn: col,
         searchAllPanes: true
       });
       this.emit('matched', match.id);
-    }.bind(this));
+    });
   };
 
   ErrorMatcher.prototype._parse = function () {

--- a/spec/build-error-match-spec.js
+++ b/spec/build-error-match-spec.js
@@ -301,6 +301,51 @@ describe('Error Match', function() {
       });
     });
 
+    it('should prepend `cwd` to the relative matched file if set', function () {
+      var atomBuild = {
+        cmd: 'echo __.atom-build.json__ && exit 1',
+        cwd: directory,
+        errorMatch: '__(?<file>.+)__'
+      };
+      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify(atomBuild));
+      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsFor(function () {
+        return workspaceElement.querySelector('.build .title') &&
+          workspaceElement.querySelector('.build .title').classList.contains('error');
+      });
+
+      runs(function () {
+        return atom.commands.dispatch(workspaceElement, 'build:error-match-first');
+      });
+
+      waitsFor(function () {
+        return atom.workspace.getActiveTextEditor();
+      });
+
+      runs(function () {
+        // Error match one more time to make sure `cwd` isn't prepended multiple times
+        atom.workspace.getActivePaneItem().destroy();
+      });
+
+      waitsFor(function () {
+        return !atom.workspace.getActiveTextEditor();
+      });
+
+      runs(function () {
+        return atom.commands.dispatch(workspaceElement, 'build:error-match-first');
+      });
+
+      waitsFor(function () {
+        return atom.workspace.getActiveTextEditor();
+      });
+
+      runs(function () {
+        var editor = atom.workspace.getActiveTextEditor();
+        expect(editor.getPath()).toEqual(directory + '.atom-build.json');
+      });
+    });
+
     it('should auto match error on failed build when config is set', function () {
       atom.config.set('build.scrollOnError', true);
 


### PR DESCRIPTION
`cwd` should only be prepended once, not once for every
error match issued.

Fixes #194