### PR TITLE
better default font and match editor font

### DIFF
--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -28,6 +28,7 @@ module.exports = (function() {
     atom.config.observe('build.panelOrientation', this.orientationFromConfig.bind(this));
     atom.config.observe('build.monocleHeight', this.sizeFromConfig.bind(this));
     atom.config.observe('build.minimizedHeight', this.sizeFromConfig.bind(this));
+    atom.config.observe('editor.fontFamily', this.fontFromConfig.bind(this));
 
     atom.commands.add('atom-workspace', 'build:toggle-panel', this.toggle.bind(this));
   }
@@ -75,6 +76,7 @@ module.exports = (function() {
     let orientation = atom.config.get('build.panelOrientation') || 'Bottom';
     this.panel = addfn[orientation].call(atom.workspace, { item: this });
     this.sizeFromConfig();
+    this.fontFromConfig();
   };
 
   BuildView.prototype.detach = function(force) {
@@ -94,6 +96,10 @@ module.exports = (function() {
 
   BuildView.prototype.sizeFromConfig = function() {
     this.setSizePercent(atom.config.get(this.monocle ? 'build.monocleHeight' : 'build.minimizedHeight'));
+  };
+
+  BuildView.prototype.fontFromConfig = function() {
+    this.output.css("font-family", atom.config.get('editor.fontFamily'));
   };
 
   BuildView.prototype.visibleFromConfig = function(val) {

--- a/styles/build.less
+++ b/styles/build.less
@@ -41,7 +41,7 @@
     overflow: auto;
     word-wrap: break-word;
     white-space: pre-wrap;
-    font-family: monospace;
+    font-family: 'Menlo', 'Consolas', 'DejaVu Sans Mono', monospace;
   }
 
   .status {


### PR DESCRIPTION
I think the output view looks a lot better when it uses the font set for the editor, instead of simply going with whatever the user agent default is for `monospace`. This updates the stylesheet to default to the same default fonts as the core stylesheet of Atom, and uses the configured font by creating an inline style on the output element.