### PR TITLE
added management of relative paths within sub projects

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -87,6 +87,13 @@ module.exports = {
       default: 'Bottom',
       enum: [ 'Bottom', 'Top', 'Left', 'Right' ],
       order: 8
+    },
+    subProjects: {
+      title: 'Sub Projects',
+      description: 'Comma separated list of sub folders or "*" for automatic (for example if you use qmake subdirs)',
+      type: 'string',
+      default: '',
+      order: 9
     }
   },
 

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -51,7 +51,24 @@ module.exports = (function () {
     }
 
     if (!path.isAbsolute(file)) {
-      file = this.cwd + path.sep + file;
+      var match_file = this.cwd + path.sep + file;
+      if( !fs.existsSync(match_file) ) {
+        var files = atom.config.get('build.subProjects');
+        if(files == "*") {
+          files = fs.readdirSync(this.cwd);
+        } else {
+          files = files.split(',');
+        }
+        files.forEach((f) => {
+          match_file = this.cwd + path.sep + f + path.sep + file;
+          if( fs.existsSync(match_file) ) {
+            file = match_file;
+          }
+        });
+      }
+      else {
+        file = match_file;
+      }
     }
 
     var row = match.line ? match.line - 1 : 0; /* Because atom is zero-based */


### PR DESCRIPTION
I'm using qmake with several PRO files where usually sub projects are located within sub directories. Because of that the Makefiles end up in those sub directories but atom-build doesn't get that because CWD isn't changing.
The best solution would be to parse the "Entering directory X..." messages from make. But I'm not so familiar with js and so I found a more quick-hack solution.
Helps me a lot because now atom-build error messages lead me to the source code again. 