### PR TITLE
Improve default keybindings for Linux/Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 Automatically build your project inside your new favorite editor, Atom.
 
-  * `cmd-alt-b` / `ctrl-alt-b` builds your project.
-  * `cmd-alt-g` / `ctrl-alt-g` cycles through causes of build error. See [Error Matching](#error-match).
-  * `cmd-alt-h` / `ctrl-alt-h` goes to the first build error. See [Error Matching](#error-match).
-  * `cmd-alt-v` / `ctrl-alt-v` Toggles the build panel.
-  * `cmd-alt-t` / `ctrl-alt-t` Displays the available build targets.
+  * `cmd-alt-b` / `ctrl-alt-b` / `f9` builds your project.
+  * `cmd-alt-g` / `ctrl-alt-g` / `f4` cycles through causes of build error. See [Error Matching](#error-match).
+  * `cmd-alt-h` / `ctrl-alt-h` / `shift-f4` goes to the first build error. See [Error Matching](#error-match).
+  * `cmd-alt-v` / `ctrl-alt-v` / `f8` Toggles the build panel.
+  * `cmd-alt-t` / `ctrl-alt-t` / `f7` Displays the available build targets.
   * `escape` terminates build / closes the build window.
 
 ![work work](https://noseglid.github.io/atom-build.gif)
@@ -93,7 +93,7 @@ correct file, row and column of the error. For instance:
 ```
 
 Would be matched with the regular expression: `\n(?<file>[\\/0-9a-zA-Z\\._]+):(?<line>\\d+):(?<col>\\d+)`.
-After the build has failed, pressing `cmd-alt-g` (OS X) or `ctrl-alt-g` (Linux/Windows), `a.c` would be
+After the build has failed, pressing `cmd-alt-g` (OS X) or `f4` (Linux/Windows), `a.c` would be
 opened and the cursor would be placed at row 4, column 26.
 
 Note the syntax for match groups. This is from the [XRegExp](http://xregexp.com/) package
@@ -115,7 +115,7 @@ If your build outputs multiple errors, all will be matched. Press `cmd-alt-g` (O
 to cycle through the errors (in the order they appear, first on stderr then on stdout).
 
 Often, the first error is the most interesting since other errors tend to be secondary faults caused by that first one.
-To jump to the first error you can use `cmd-alt-h` (OS X) or `ctrl-alt-h` (Linux/Windows) at any point to go to the first error.
+To jump to the first error you can use `cmd-alt-h` (OS X) or `shift-f4` (Linux/Windows) at any point to go to the first error.
 
 ## Service API (for package developers)
 

--- a/keymaps/build.json
+++ b/keymaps/build.json
@@ -13,6 +13,13 @@
     "ctrl-alt-h": "build:error-match-first",
     "ctrl-alt-t": "build:select-active-target"
   },
+  "atom-workspace, atom-text-editor": {
+    "f9": "build:trigger",
+    "f8": "build:toggle-panel",
+    "f4": "build:error-match",
+    "shift-f4": "build:error-match-first",
+    "f7": "build:select-active-target"
+  },
   ".build": {
     "escape": "build:stop"
   },


### PR DESCRIPTION
Currently the default key bindings on Linux and Windows aren't optimal. For example `ctrl-alt-t` is already used by most distros to open a terminal, see #163. In general it's uncommon for Linux apps to use `ctrl-alt-*` keybindings as they are usually used by system apps.

After looking through the issues, it looks to me that only people on Linux/Windows have problems with the default keybindings: #168, #198.

Also note that `ctrl-alt-*` has some problems on Windows, see this post which advises not to use them on Windows at all: https://github.com/atom/atom-keymap/issues/35#issuecomment-117284074

Last but not least they are rather uncommon among existing build apps like Sublime Text or CodeBlocks.

I've tried to find some new defaults, here is my reasoning for them:

* `f4` error-match: This is the keybindings Sublime Text uses.
* `shift-f4` error-match-first: Should be similar to error-match, therefore added shift.
* `f9` trigger: This is used by CodeBlocks for build and run
* `f7` select-active-target: To match Visual Studio's build shortcut. Maybe change to `shift-f9`?
* `f8` toggle-panel: A key between f7 and f9 :D I'm not sure about this one.

Also see https://github.com/noseglid/atom-build/issues/168#issuecomment-136391472 for suggestions.

What do you think? :)