### PR TITLE
Use regexps with '/g' modifier to replace all matches of built-in vars.

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -283,10 +283,10 @@ module.exports = {
     if (editor && 'untitled' !== editor.getTitle()) {
       var activeFile = fs.realpathSync(editor.getPath());
       var activeFilePath = path.dirname(activeFile);
-      value = value.replace('{FILE_ACTIVE}', activeFile);
-      value = value.replace('{FILE_ACTIVE_PATH}', activeFilePath);
-      value = value.replace('{FILE_ACTIVE_NAME}', path.basename(activeFile));
-      value = value.replace('{FILE_ACTIVE_NAME_BASE}', path.basename(activeFile, path.extname(activeFile)));
+      value = value.replace(/{FILE_ACTIVE}/g, activeFile);
+      value = value.replace(/{FILE_ACTIVE_PATH}/g, activeFilePath);
+      value = value.replace(/{FILE_ACTIVE_NAME}/g, path.basename(activeFile));
+      value = value.replace(/{FILE_ACTIVE_NAME_BASE}/g, path.basename(activeFile, path.extname(activeFile)));
     }
     var projectPaths = _.map(atom.project.getPaths(), function(projectPath) {
       try {
@@ -297,9 +297,9 @@ module.exports = {
       return activeFilePath && activeFilePath.startsWith(projectPath);
     }) || projectPaths[0];
 
-    value = value.replace('{PROJECT_PATH}', projectPath);
+    value = value.replace(/{PROJECT_PATH}/g, projectPath);
     if (atom.project.getRepositories[0]) {
-      value = value.replace('{REPO_BRANCH_SHORT}', atom.project.getRepositories()[0].getShortHead());
+      value = value.replace(/{REPO_BRANCH_SHORT}/g, atom.project.getRepositories()[0].getShortHead());
     }
 
     return value;


### PR DESCRIPTION
As far as I understand javascript's "replace" with string arguments does only single replacement. I needed to replace all matches when building some of the Go projects. The use case was to redefine an environment variable like so: `"GOPATH": "{PROJECT_PATH}:{PROJECT_PATH}/vendor"`. With this fix it actually works.