### PR TITLE
improve layout in sidebar mode

### DIFF
--- a/styles/build.less
+++ b/styles/build.less
@@ -13,7 +13,7 @@
   .build-timer {
     display: inline-block;
     width: 5em;
-    margin-right: 10px;
+    margin-right: @component-padding;
   }
 
   .title.error {
@@ -37,7 +37,7 @@
   .output {
     transition: 0.5s ease-in-out;
     transition-property: width, height;
-    padding: 10px 0 @status-panel-height 10px;
+    padding: @component-padding 0 @status-panel-height @component-padding;
     min-height: 100px;
     overflow: auto;
     word-wrap: break-word;
@@ -63,7 +63,7 @@
 .btn-container {
   .btn {
     float: right;
-    margin: 10px 10px 0 0;
+    margin: @component-padding @component-padding 0 0;
     color: @text-color-info;
   }
 
@@ -73,5 +73,22 @@
 
   .new-row {
     clear: both;
+  }
+}
+
+.panel-left .build,
+.panel-right .build {
+  .btn-container {
+    float: none !important;
+    .new-row {
+      clear: none;
+    }
+    .btn:last-child {
+      margin-left: @component-padding;
+    }
+  }
+  .output {
+    min-width: 200px;
+    padding-right: @component-padding;
   }
 }


### PR DESCRIPTION
Some css tweaks:

- use `@component-padding` from ui-theme for padding instead of `10px`
- set minimum width
- all buttons in a row so output gets to use the entire width of the panel

Before  
![before](https://cloud.githubusercontent.com/assets/2543659/10934137/3935e752-82de-11e5-816c-fdaa34555996.png)

After
![after](https://cloud.githubusercontent.com/assets/2543659/10934149/4702dcaa-82de-11e5-940b-118bafabf5d3.png)
