### PR TITLE
Better support for multiple root projects

### DIFF
--- a/lib/atom-build.js
+++ b/lib/atom-build.js
@@ -55,27 +55,21 @@ module.exports.settings = function (cwd) {
   return config;
 };
 
-let fileWatchers = [];
 module.exports.on = function (ev, cb) {
+  this.fileWatchers = this.fileWatchers || [];
   if ('refresh' !== ev || !this.files) {
     return;
   }
 
-  fileWatchers.forEach(watcher => {
-    watcher.close();
-  });
-
-  fileWatchers = this.files.map(file => {
-    return fs.watch(file, cb);
-  });
+  this.fileWatchers.push.apply(this.fileWatchers, this.files.map(file => fs.watch(file, cb)));
 };
 
 module.exports.off = function (ev) {
+  this.fileWatchers = this.fileWatchers || [];
   if ('refresh' !== ev) {
     return;
   }
 
-  fileWatchers.forEach(watcher => {
-    watcher.close();
-  });
+  this.fileWatchers.forEach(watcher => watcher.close());
+  this.fileWatchers = [];
 };

--- a/lib/build.js
+++ b/lib/build.js
@@ -98,14 +98,15 @@ module.exports = {
 
     this.buildView = new BuildView();
 
-    this.cmd = {};
     this.targets = {};
-    this.activeTarget = null;
-    this.match = [];
+    this.activeTarget = {};
+    this.targetsLoading = {};
+
     this.stdout = new Buffer(0);
     this.stderr = new Buffer(0);
     this.errorMatcher = new ErrorMatcher();
 
+    atom.commands.add('atom-workspace', 'build:refresh-targets', () => this.refreshTargets());
     atom.commands.add('atom-workspace', 'build:trigger', this.build.bind(this, 'trigger'));
     atom.commands.add('atom-workspace', 'build:select-active-target', this.selectActiveTarget.bind(this));
     atom.commands.add('atom-workspace', 'build:stop', this.stop.bind(this));
@@ -141,12 +142,21 @@ module.exports = {
       this.buildView.link(text, id, callback);
     });
 
-    this.refreshTargets().catch(function(e) {});
+    atom.packages.onDidActivateInitialPackages(() => this.refreshTargets());
+
+    let projectPaths = atom.project.getPaths();
+    atom.project.onDidChangePaths(() => {
+      let addedPaths = atom.project.getPaths().filter(el => projectPaths.indexOf(el) === -1);
+      this.refreshTargets(addedPaths);
+      projectPaths = atom.project.getPaths();
+    });
   },
 
   deactivate: function() {
     tools.forEach(tool => {
-      tool.off.apply(tool.ctx, [ 'refresh' ]);
+      if (tool.off) {
+        _.forEach(tool.ctx, (ctx, path) => tool.off.apply(ctx, [ 'refresh' ]));
+      }
     });
     if (this.child) {
       this.child.removeAllListeners();
@@ -167,7 +177,7 @@ module.exports = {
       return atom.project.getPaths()[0];
     } else {
       /* otherwise, build the one in the root of the active editor */
-      return _.find(atom.project.getPaths(), function (path) {
+      return atom.project.getPaths().sort((a, b) => (b.length - a.length)).find(path => {
         var realpath = fs.realpathSync(path);
         return textEditor.getPath().substr(0, realpath.length) === realpath;
       });
@@ -180,101 +190,115 @@ module.exports = {
       args: [],
       cwd: path,
       sh: true,
-      errorMatch: ''
+      errorMatch: '',
+      dispose: Function.prototype
     };
   },
 
-  refreshTargets: function() {
-    var path = this.activePath();
-    var prioritizedTarget;
+  refreshTargets: function(refreshPaths) {
+    refreshPaths = refreshPaths || atom.project.getPaths();
 
-    return Promise.resolve(tools)
-      .then(function () {
-        if (!path) {
-          throw new BuildError('No active project', 'No project is active, don\'t know what to build...');
+    let pathPromise = refreshPaths.map((path) => {
+      this.targetsLoading[path] = true;
+      this.targets[path] = this.targets[path] || [];
+      let settingsPromise = tools.filter((tool) => {
+        tool.ctx = tool.ctx || [];
+        tool.ctx[path] = tool.ctx[path] || {};
+        return tool.isEligable.apply(tool.ctx[path], [ path ]);
+      }).map((tool) => {
+        GoogleAnalytics.sendEvent('build', 'tool eligible', tool.niceName);
+
+        if (tool.on) {
+          tool.off.apply(tool.ctx[path], [ 'refresh' ]);
+          tool.on.apply(tool.ctx[path], [ 'refresh', this.refreshTargets.bind(this, [ path ]) ]);
         }
 
-        return _.filter(tools, function (tool) {
-          tool.ctx = {};
-          return tool.isEligable.apply(tool.ctx, [ path ]);
-        });
-      })
-      .then(tools => {
-        return Promise.all(_.map(tools, tool => {
-          GoogleAnalytics.sendEvent('build', 'tool eligible', tool.niceName);
-
-          if (tool.on) {
-            tool.off.apply(tool.ctx, [ 'refresh' ]);
-            tool.on.apply(tool.ctx, [ 'refresh', this.refreshTargets.bind(this) ]);
+        return Promise.resolve().then(() => {
+          return tool.settings.apply(tool.ctx[path], [ path ]);
+        }).catch(function (err) {
+          if (err instanceof SyntaxError) {
+            atom.notifications.addError('Invalid build file.', {
+              detail: 'You have a syntax error in your build file: ' + err.message,
+              dismissable: true
+            });
+          } else {
+            atom.notifications.addError('Ooops. Something went wrong.', {
+              detail: err.message + (err.stack ? '\n' + err.stack : ''),
+              dismissable: true
+            });
           }
-
-          return tool.settings.apply(tool.ctx, [ path ]);
-        }));
-      })
-      .then(_.flatten)
-      .then((settings) => {
-        if (0 === _.size(settings)) {
-          throw new BuildError('No eligible build tool.', 'No tool can provide any build configurations.');
-        }
-
-        prioritizedTarget = settings[0].name;
-        return _.map(settings, (setting) => {
-          return [ setting.name, _.defaults(setting, this.cmdDefaults(path)) ];
         });
-      })
-      .then(_.zipObject)
-      .then((targets) => {
-        if (_.isNull(this.activeTarget) || _.isUndefined(targets[this.activeTarget])) {
+      });
+
+      return Promise.all(settingsPromise).then((settings) => {
+        settings = [].concat.apply([], settings).filter(Boolean).map(setting =>
+          _.defaults(setting, this.cmdDefaults(path))
+        );
+
+        if (_.isNull(this.activeTarget[path]) || !settings.find(s => s.name === this.activeTarget[path])) {
           /* Active target has been removed or not set. Set it to the highest prio target */
-          this.activeTarget = prioritizedTarget;
+          this.activeTarget[path] = settings[0] ? settings[0].name : undefined;
         }
 
-        _.forEach(this.targets, function (target) {
-          target.dispose(); // Gets rid of keymaps and commands registered
-        });
+        this.targets[path].forEach(target => target.dispose());
 
-        _.forEach(targets, (target, targetName) => {
-          if (!target.keymap) {
-            target.dispose = _.noop;
+        settings.forEach((setting, index) => {
+          if (!setting.keymap) {
             return;
           }
 
-          GoogleAnalytics.sendEvent('keymap', 'registered', target.keymap);
-          var commandName = 'build:trigger:' + targetName;
+          GoogleAnalytics.sendEvent('keymap', 'registered', setting.keymap);
+          var commandName = 'build:trigger:' + setting.name;
           var keymapSpec = { 'atom-workspace': {} };
-          keymapSpec['atom-workspace'][target.keymap] = commandName;
-          var keymapDispose = atom.keymaps.add(targetName, keymapSpec);
+          keymapSpec['atom-workspace'][setting.keymap] = commandName;
+          var keymapDispose = atom.keymaps.add(setting.name, keymapSpec);
           var commandDispose = atom.commands.add('atom-workspace', commandName, this.build.bind(this, 'trigger'));
-          target.dispose = function () {
+          settings[index].dispose = function () {
             keymapDispose.dispose();
             commandDispose.dispose();
           };
         });
 
-        return (this.targets = targets);
+        this.targets[path] = settings;
+        this.targetsLoading[path] = false;
       });
+    });
+
+    Promise.all(pathPromise).then((entries) => {
+      if (entries.length === 0) {
+        return;
+      }
+
+      let rows = refreshPaths.map(path => `${this.targets[path].length} targets at: ${path}`);
+      atom.notifications.addInfo('Build targets parsed.', {
+        detail: rows.join('\n')
+      });
+    });
   },
 
   selectActiveTarget: function() {
-    var targetsView = new TargetsView();
-    targetsView.setLoading('Loading project build targets...\u2026');
+    let path = this.activePath();
+    let targets = this.targets[path];
+    let targetsView = new TargetsView();
 
-    this.refreshTargets().then((targets) => {
-      targetsView.setActiveTarget(this.activeTarget);
-      targetsView.setItems(_.keys(targets));
-      return targetsView.awaitSelection();
-    }).then((newTarget) => {
-      this.activeTarget = newTarget;
+    if (this.targetsLoading[path]) {
+      return targetsView.setLoading('Loading project build targets\u2026');
+    }
 
-      var workspaceElement = atom.views.getView(atom.workspace);
+    targetsView.setActiveTarget(this.activeTarget[path]);
+    targetsView.setItems((targets || []).map(target => target.name));
+    targetsView.awaitSelection().then((newTarget) => {
+      this.activeTarget[path] = newTarget;
+
+      let workspaceElement = atom.views.getView(atom.workspace);
       atom.commands.dispatch(workspaceElement, 'build:trigger');
     }).catch(function (err) {
       targetsView.setError(err.message);
     });
   },
 
-  replace: function(value) {
-    var env = _.extend(_.clone(process.env), this.cmd.env);
+  replace: function(value, targetEnv) {
+    var env = _.extend(_.clone(process.env), targetEnv);
     value = value.replace(/\$(\w+)/g, function(match, name) {
       return name in env ? env[name] : match;
     });
@@ -306,97 +330,90 @@ module.exports = {
   },
 
   startNewBuild: function(source, targetName) {
-    this.cmd = {};
-    this.match = [];
+    let path = this.activePath();
 
-    Promise.resolve()
-      .then(() => {
-        return (this.activeTarget) ? this.targets : this.refreshTargets();
-      })
-      .then((targets) => {
-        this.cmd = targets[targetName ? targetName : this.activeTarget];
-        GoogleAnalytics.sendEvent('build', 'triggered');
+    Promise.resolve(this.targets[path]).then(targets => {
+      if (!targets) {
+        throw new BuildError('No eligible build target.', 'No configuration to build this project exists.');
+      }
 
-        if (!this.cmd.exec) {
-          atom.notifications.addError('Invalid build file.', { detail: 'No executable command specified.' });
+      let target = targets.find(target => (targetName) ? target.name === targetName : target.name === this.activeTarget[path]);
+      GoogleAnalytics.sendEvent('build', 'triggered');
+
+      if (!target.exec) {
+        throw new BuildError('Inavlid build file.', 'No executable command specified.');
+      }
+
+      var env = _.extend(_.clone(process.env), target.env);
+      _.each(env, (value, key, list) => {
+        list[key] = this.replace(value, target.env);
+      });
+
+      let exec = this.replace(target.exec, target.env);
+      var args = _.map(target.args, (arg) => this.replace(arg, target.env));
+      let cwd = this.replace(target.cwd, target.env);
+
+      this.child = child_process.spawn(
+        target.sh ? '/bin/sh' : exec,
+        target.sh ? [ '-c', [ exec ].concat(args).join(' ') ] : args,
+        { cwd: cwd, env: env }
+      );
+
+      this.stdout = new Buffer(0);
+      this.child.stdout.on('data', (buffer) => {
+        this.stdout = Buffer.concat([ this.stdout, buffer ]);
+        this.buildView.append(buffer);
+      });
+
+      this.stderr = new Buffer(0);
+      this.child.stderr.on('data', (buffer) => {
+        this.stderr = Buffer.concat([ this.stderr, buffer ]);
+        this.buildView.append(buffer);
+      });
+
+      this.child.on('error', (err) => {
+        this.buildView.append((target.sh ? 'Unable to execute with sh: ' : 'Unable to execute: ') + exec + '\n');
+
+        if (/\s/.test(exec) && !target.sh) {
+          this.buildView.append('`cmd` cannot contain space. Use `args` for arguments.\n');
+        }
+
+        if ('ENOENT' === err.code) {
+          this.buildView.append('Make sure `cmd` and `cwd` exists and have correct access permissions.');
+        }
+      });
+
+      this.child.on('close', (exitCode) => {
+        this.errorMatcher.set(target.errorMatch, cwd, this.buildView.output.text());
+
+        var success = 0 === exitCode && !this.errorMatcher.hasMatch();
+        this.buildView.buildFinished(success);
+        if (success) {
+          GoogleAnalytics.sendEvent('build', 'succeeded');
+          this.finishedTimer = setTimeout(() => {
+            this.buildView.detach();
+          }, 1000);
+        } else {
+          if (atom.config.get('build.scrollOnError')) {
+            this.errorMatcher.matchFirst();
+          }
+          GoogleAnalytics.sendEvent('build', 'failed');
+        }
+        this.child = null;
+      });
+
+      this.buildView.buildStarted();
+      this.buildView.append((target.sh ? 'Executing with sh: ' : 'Executing: ') + exec + [ ' ' ].concat(args).join(' ') + '\n');
+    }).catch(function (err) {
+      if (err instanceof BuildError) {
+        if (source === 'save') {
+          // If there is no eligible build tool, and cause of build was a save, stay quiet.
           return;
         }
 
-        var env = _.extend(_.clone(process.env), this.cmd.env);
-        _.each(env, (value, key, list) => {
-          list[key] = this.replace(value);
-        });
-
-        var args = _.map(this.cmd.args, this.replace.bind(this));
-
-        this.cmd.exec = this.replace(this.cmd.exec);
-
-        this.child = child_process.spawn(
-          this.cmd.sh ? '/bin/sh' : this.cmd.exec,
-          this.cmd.sh ? [ '-c', [ this.cmd.exec ].concat(args).join(' ') ] : args,
-          { cwd: this.replace(this.cmd.cwd), env: env }
-        );
-
-        this.stdout = new Buffer(0);
-        this.child.stdout.on('data', (buffer) => {
-          this.stdout = Buffer.concat([ this.stdout, buffer ]);
-          this.buildView.append(buffer);
-        });
-
-        this.stderr = new Buffer(0);
-        this.child.stderr.on('data', (buffer) => {
-          this.stderr = Buffer.concat([ this.stderr, buffer ]);
-          this.buildView.append(buffer);
-        });
-
-        this.child.on('error', (err) => {
-          this.buildView.append((this.cmd.sh ? 'Unable to execute with sh: ' : 'Unable to execute: ') + this.cmd.exec + '\n');
-
-          if (/\s/.test(this.cmd.exec) && !this.cmd.sh) {
-            this.buildView.append('`cmd` cannot contain space. Use `args` for arguments.\n');
-          }
-
-          if ('ENOENT' === err.code) {
-            this.buildView.append('Make sure `cmd` and `cwd` exists and have correct access permissions.');
-          }
-        });
-
-        this.child.on('close', (exitCode) => {
-          var t = this.targets[this.activeTarget];
-          this.errorMatcher.set(t.errorMatch, this.replace(t.cwd), this.buildView.output.text());
-
-          var success = 0 === exitCode && !this.errorMatcher.hasMatch();
-          this.buildView.buildFinished(success);
-          if (success) {
-            GoogleAnalytics.sendEvent('build', 'succeeded');
-            this.finishedTimer = setTimeout(() => {
-              this.buildView.detach();
-            }, 1000);
-          } else {
-            if (atom.config.get('build.scrollOnError')) {
-              this.errorMatcher.matchFirst();
-            }
-            GoogleAnalytics.sendEvent('build', 'failed');
-          }
-          this.child = null;
-        });
-
-        this.buildView.buildStarted();
-        this.buildView.append((this.cmd.sh ? 'Executing with sh: ' : 'Executing: ') + this.cmd.exec + [ ' ' ].concat(args).join(' ') + '\n');
-      }).catch(function (err) {
-        if (err instanceof BuildError) {
-          if (source === 'save') {
-            // If there is no eligible build tool, and cause of build was a save, stay quiet.
-            return;
-          }
-
-          atom.notifications.addWarning(err.name, { detail: err.message });
-        } else if (err instanceof SyntaxError) {
-          atom.notifications.addError('Invalid build file.', { detail: 'You have a syntax error in your build file: ' + err.message });
-        } else {
-          atom.notifications.addError('Ooops. Something went wrong.', { detail: err.message + (err.stack ? '\n' + err.stack : '') });
-        }
-      });
+        atom.notifications.addWarning(err.name, { detail: err.message });
+      }
+    });
   },
 
   abort: function(cb) {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "fs-extra": "^0.23.0",
     "temp": "^0.8.1",
-    "atom-build-spec-helpers": "^0.1.0",
+    "atom-build-spec-helpers": "^0.2.0",
     "jshint": "^2.5.11",
     "jscs": "^1.9.0"
   },

--- a/spec/build-confirm-spec.js
+++ b/spec/build-confirm-spec.js
@@ -4,6 +4,7 @@
 var _ = require('lodash');
 var fs = require('fs-extra');
 var temp = require('temp');
+var specHelpers = require('atom-build-spec-helpers');
 
 describe('Confirm', function() {
   var directory = null;
@@ -103,11 +104,11 @@ describe('Confirm', function() {
       }));
 
       waitsForPromise(function() {
-        return atom.workspace.open('.atom-build.json');
-      });
-
-      waitsForPromise(function() {
-        return atom.workspace.open();
+        return Promise.all([
+          specHelpers.refreshAwaitTargets(),
+          atom.workspace.open('.atom-build.json'),
+          atom.workspace.open()
+        ]);
       });
 
       runs(function() {
@@ -132,29 +133,27 @@ describe('Confirm', function() {
     it('should save and build when selecting save and build', function() {
       expect(workspaceElement.querySelector('.build-confirm')).not.toExist();
 
+      fs.writeFileSync(directory + 'catme', 'Surprising is the passing of time but not so, as the time of passing.');
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-        cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
+        cmd: 'cat catme'
       }));
 
       waitsForPromise(function() {
-        return atom.workspace.open('.atom-build.json');
+        return Promise.all([
+          specHelpers.refreshAwaitTargets(),
+          atom.workspace.open('catme')
+        ]);
       });
 
       runs(function() {
         var editor = atom.workspace.getActiveTextEditor();
-        editor.setText(JSON.stringify({
-          cmd: 'echo kansas'
-        }));
+        editor.setText('kansas');
         atom.commands.dispatch(workspaceElement, 'build:trigger');
       });
 
-      waitsFor(function() {
-        return workspaceElement.querySelector(':focus');
-      });
+      waitsFor(() => workspaceElement.querySelector(':focus'));
 
-      runs(function() {
-        workspaceElement.querySelector(':focus').click();
-      });
+      runs(() => workspaceElement.querySelector(':focus').click());
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -172,19 +171,21 @@ describe('Confirm', function() {
     it('should build but not save when opting so', function() {
       expect(workspaceElement.querySelector('.build-confirm')).not.toExist();
 
+      fs.writeFileSync(directory + 'catme', 'Surprising is the passing of time but not so, as the time of passing.');
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-        cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
+        cmd: 'cat catme'
       }));
 
       waitsForPromise(function() {
-        return atom.workspace.open('.atom-build.json');
+        return Promise.all([
+          specHelpers.refreshAwaitTargets(),
+          atom.workspace.open('catme')
+        ]);
       });
 
       runs(function() {
         var editor = atom.workspace.getActiveTextEditor();
-        editor.setText(JSON.stringify({
-          cmd: 'echo kansas'
-        }));
+        editor.setText('catme');
         atom.commands.dispatch(workspaceElement, 'build:trigger');
       });
 
@@ -212,19 +213,21 @@ describe('Confirm', function() {
     it('should do nothing when cancelling', function() {
       expect(workspaceElement.querySelector('.build-confirm')).not.toExist();
 
+      fs.writeFileSync(directory + 'catme', 'Surprising is the passing of time but not so, as the time of passing.');
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-        cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
+        cmd: 'cat catme'
       }));
 
       waitsForPromise(function() {
-        return atom.workspace.open('.atom-build.json');
+        return Promise.all([
+          specHelpers.refreshAwaitTargets(),
+          atom.workspace.open('catme')
+        ]);
       });
 
       runs(function() {
         var editor = atom.workspace.getActiveTextEditor();
-        editor.setText(JSON.stringify({
-          cmd: 'echo kansas'
-        }));
+        editor.setText('kansas');
         atom.commands.dispatch(workspaceElement, 'build:trigger');
       });
 
@@ -255,7 +258,10 @@ describe('Confirm', function() {
       }));
 
       waitsForPromise(function() {
-        return atom.workspace.open('.atom-build.json');
+        return Promise.all([
+          specHelpers.refreshAwaitTargets(),
+          atom.workspace.open('.atom-build.json')
+        ]);
       });
 
       runs(function() {

--- a/spec/build-error-match-spec.js
+++ b/spec/build-error-match-spec.js
@@ -2,6 +2,7 @@
 
 var fs = require('fs-extra');
 var temp = require('temp');
+var specHelpers = require('atom-build-spec-helpers');
 
 describe('Error Match', function() {
   var errorMatchAtomBuildFile = __dirname + '/fixture/.atom-build.error-match.json';
@@ -52,7 +53,9 @@ describe('Error Match', function() {
         errorMatch: '(invalidRegex'
       }));
 
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -75,7 +78,10 @@ describe('Error Match', function() {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchAtomBuildFile));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -103,7 +109,10 @@ describe('Error Match', function() {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchNoFileBuildFile));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -129,7 +138,10 @@ describe('Error Match', function() {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchNLCAtomBuildFile));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -154,7 +166,10 @@ describe('Error Match', function() {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchMultiAtomBuildFile));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -216,7 +231,10 @@ describe('Error Match', function() {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchMultiFirstAtomBuildFile));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -275,12 +293,14 @@ describe('Error Match', function() {
     });
 
     it('should open the the file even if tool gives absolute path', function () {
-      var atomBuild = {
+      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
         cmd: 'echo __' + directory + '.atom-build.json__ && return 1',
         errorMatch: '__(?<file>.+)__'
-      };
-      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify(atomBuild));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+      }));
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -308,7 +328,10 @@ describe('Error Match', function() {
         errorMatch: '__(?<file>.+)__'
       };
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify(atomBuild));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function () {
         return workspaceElement.querySelector('.build .title') &&
@@ -351,7 +374,9 @@ describe('Error Match', function() {
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchAtomBuildFile));
 
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -374,7 +399,10 @@ describe('Error Match', function() {
     it('should scroll the build panel to the text of the error', function () {
       expect(workspaceElement.querySelector('.build')).not.toExist();
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchLongOutputAtomBuildFile));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -386,28 +414,32 @@ describe('Error Match', function() {
       });
 
       waits(100);
+      let firstScrollTop;
       runs(function() {
-        expect(workspaceElement.querySelector('.build .output').scrollTop).toEqual(101);
+        firstScrollTop = workspaceElement.querySelector('.build .output').scrollTop;
         atom.commands.dispatch(workspaceElement, 'build:error-match');
       });
 
       waits(100);
       runs(function() {
-        expect(workspaceElement.querySelector('.build .output').scrollTop).toEqual(168);
+        expect(workspaceElement.querySelector('.build .output').scrollTop).toBeGreaterThan(firstScrollTop);
         atom.commands.dispatch(workspaceElement, 'build:error-match');
       });
 
       waits(100);
       runs(function() {
         /* Should wrap around to first match */
-        expect(workspaceElement.querySelector('.build .output').scrollTop).toEqual(101);
+        expect(workspaceElement.querySelector('.build .output').scrollTop).toEqual(firstScrollTop);
       });
     });
 
     it('match-first should scroll the build panel', function () {
       expect(workspaceElement.querySelector('.build')).not.toExist();
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchLongOutputAtomBuildFile));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -419,20 +451,21 @@ describe('Error Match', function() {
       });
 
       waits(100);
+      let firstScrollTop;
       runs(function() {
-        expect(workspaceElement.querySelector('.build .output').scrollTop).toEqual(101);
+        firstScrollTop = workspaceElement.querySelector('.build .output').scrollTop;
         atom.commands.dispatch(workspaceElement, 'build:error-match');
       });
 
       waits(100);
       runs(function() {
-        expect(workspaceElement.querySelector('.build .output').scrollTop).toEqual(168);
+        expect(workspaceElement.querySelector('.build .output').scrollTop).toBeGreaterThan(firstScrollTop);
         atom.commands.dispatch(workspaceElement, 'build:error-match-first');
       });
 
       waits(100);
       runs(function() {
-        expect(workspaceElement.querySelector('.build .output').scrollTop).toEqual(101);
+        expect(workspaceElement.querySelector('.build .output').scrollTop).toEqual(firstScrollTop);
       });
     });
 
@@ -440,7 +473,10 @@ describe('Error Match', function() {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchMultiMatcherAtomBuildFile));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&

--- a/spec/build-keymap-spec.js
+++ b/spec/build-keymap-spec.js
@@ -50,9 +50,9 @@ describe('Keymap', function() {
         }
       }));
 
-      runs(function () {
-        atom.commands.dispatch(workspaceElement, 'build:trigger');
-      });
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function () {
         return workspaceElement.querySelector('.build .title') &&
@@ -95,9 +95,9 @@ describe('Keymap', function() {
         }
       }));
 
-      runs(function () {
-        atom.commands.dispatch(workspaceElement, 'build:trigger');
-      });
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function () {
         return workspaceElement.querySelector('.build .title') &&
@@ -158,9 +158,9 @@ describe('Keymap', function() {
         }
       }));
 
-      runs(function () {
-        atom.commands.dispatch(workspaceElement, 'build:trigger');
-      });
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function () {
         return workspaceElement.querySelector('.build .title') &&
@@ -200,7 +200,11 @@ describe('Keymap', function() {
         }));
       });
 
-      waits(300); // Custom file is reloaded automatically
+      waitsForPromise(() => specHelpers.awaitTargets());
+
+      waitsFor(function() {
+        return !workspaceElement.querySelector('.build .title');
+      });
 
       runs(function () {
         specHelpers.keydown('k', { ctrl: true, alt: true, element: workspaceElement });

--- a/spec/build-spec.js
+++ b/spec/build-spec.js
@@ -59,7 +59,10 @@ describe('Build', function() {
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
         cmd: 'echo Very bad... && exit 1'
       }));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -79,7 +82,10 @@ describe('Build', function() {
         cmd: 'echo __ERROR__ && exit 0',
         errorMatch: 'ERROR'
       }));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -93,7 +99,10 @@ describe('Build', function() {
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
         cmd: 'echo "Building, this will take some time..." && sleep 30 && echo "Done!"'
       }));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       // Let build run for one second before we terminate it
       waits(1000);
@@ -141,7 +150,10 @@ describe('Build', function() {
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
         cmd: 'echo hello world'
       }));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title').classList.contains('success');
@@ -166,7 +178,10 @@ describe('Build', function() {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(goodAtomBuildfile));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -183,7 +198,10 @@ describe('Build', function() {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(shellAtomBuildfile));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -200,7 +218,10 @@ describe('Build', function() {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(shTrueAtomBuildFile));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -217,7 +238,10 @@ describe('Build', function() {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(shFalseAtomBuildFile));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -234,7 +258,10 @@ describe('Build', function() {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(shDefaultAtomBuildFile));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -251,7 +278,10 @@ describe('Build', function() {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(syntaxErrorAtomBuildFile));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return atom.notifications.getNotifications().length > 0;
@@ -272,7 +302,10 @@ describe('Build', function() {
         cmd: 'echo first'
       }));
 
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
       waitsFor(function () {
         return workspaceElement.querySelector('.build .title') &&
           workspaceElement.querySelector('.build .title').classList.contains('success');
@@ -318,12 +351,13 @@ describe('Build', function() {
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(replaceAtomBuildFile));
 
       waitsForPromise(function() {
-        return atom.workspace.open('.atom-build.json');
+        return Promise.all([
+          specHelpers.refreshAwaitTargets(),
+          atom.workspace.open('.atom-build.json')
+        ]);
       });
 
-      runs(function() {
-        atom.commands.dispatch(workspaceElement, 'build:trigger');
-      });
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -353,7 +387,10 @@ describe('Build', function() {
       }));
 
       waitsForPromise(function() {
-        return atom.workspace.open('dummy');
+        return Promise.all([
+          specHelpers.refreshAwaitTargets(),
+          atom.workspace.open('dummy')
+        ]);
       });
 
       runs(function() {
@@ -380,7 +417,10 @@ describe('Build', function() {
       });
 
       waitsForPromise(function() {
-        return atom.workspace.open('dummy');
+        return Promise.all([
+          specHelpers.refreshAwaitTargets(),
+          atom.workspace.open('dummy')
+        ]);
       });
 
       runs(function() {
@@ -417,14 +457,44 @@ describe('Build', function() {
     it('should run the second root if a file there is active', function () {
       var directory2 = fs.realpathSync(temp.mkdirSync({ prefix: 'atom-build-spec-' })) + '/';
       atom.project.addPath(directory2);
-      expect(workspaceElement.querySelector('.build-confirm')).not.toExist();
+      expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory2 + '.atom-build.json', fs.readFileSync(goodAtomBuildfile));
       waitsForPromise(function () {
-        return atom.workspace.open(directory2 + '/main.c');
+        return Promise.all([
+          specHelpers.refreshAwaitTargets(),
+          atom.workspace.open(directory2 + '/main.c'),
+        ]);
       });
 
       runs(function() {
+        atom.workspace.getActiveTextEditor().save();
+        atom.commands.dispatch(workspaceElement, 'build:trigger');
+      });
+
+      waitsFor(function() {
+        return workspaceElement.querySelector('.build .title') &&
+          workspaceElement.querySelector('.build .title').classList.contains('success');
+      });
+
+      runs(function() {
+        expect(workspaceElement.querySelector('.build')).toExist();
+        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/"cmd": "dd"/);
+      });
+    });
+
+    it('should scan new project roots when they are added', function () {
+      var directory2 = fs.realpathSync(temp.mkdirSync({ prefix: 'atom-build-spec-' })) + '/';
+      fs.writeFileSync(directory2 + '.atom-build.json', fs.readFileSync(goodAtomBuildfile));
+
+      atom.project.addPath(directory2);
+
+      waitsForPromise(() => Promise.all([
+        atom.workspace.open(directory2 + '/main.c'),
+        specHelpers.awaitTargets()
+      ]));
+
+      runs(() => {
         atom.workspace.getActiveTextEditor().save();
         atom.commands.dispatch(workspaceElement, 'build:trigger');
       });
@@ -456,7 +526,10 @@ describe('Build', function() {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(goodAtomBuildfile));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build');
@@ -474,7 +547,10 @@ describe('Build', function() {
       var activeElement = document.activeElement;
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(goodAtomBuildfile));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build');
@@ -499,7 +575,7 @@ describe('Build', function() {
       runs(function() {
         var notification = atom.notifications.getNotifications()[0];
         expect(notification.getType()).toEqual('warning');
-        expect(notification.getMessage()).toEqual('No eligible build tool.');
+        expect(notification.getMessage()).toEqual('No eligible build target.');
       });
     });
   });

--- a/spec/build-targets-spec.js
+++ b/spec/build-targets-spec.js
@@ -43,8 +43,11 @@ describe('Target', function() {
     it('should list those targets in a SelectListView (from .atom-build.json)', function () {
       waitsForPromise(function () {
         var file = __dirname + '/fixture/.atom-build.targets.json';
-        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json');
+        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json')
+          .then(() => specHelpers.refreshAwaitTargets());
       });
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(function () {
         atom.commands.dispatch(workspaceElement, 'build:select-active-target');
@@ -55,9 +58,7 @@ describe('Target', function() {
       });
 
       runs(function () {
-        var targets = _.map(workspaceElement.querySelectorAll('.select-list li.build-target'), function (el) {
-          return el.textContent;
-        });
+        var targets = _.map(workspaceElement.querySelectorAll('.select-list li.build-target'), el => el.textContent);
         expect(targets).toEqual([ 'Custom: The default build', 'Custom: Some customized build' ]);
       });
     });
@@ -65,7 +66,8 @@ describe('Target', function() {
     it('should mark the first target as active', function () {
       waitsForPromise(function () {
         var file = __dirname + '/fixture/.atom-build.targets.json';
-        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json');
+        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json')
+          .then(() => specHelpers.refreshAwaitTargets());
       });
 
       runs(function () {
@@ -86,7 +88,8 @@ describe('Target', function() {
     it('should run the selected build', function () {
       waitsForPromise(function () {
         var file = __dirname + '/fixture/.atom-build.targets.json';
-        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json');
+        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json')
+          .then(() => specHelpers.refreshAwaitTargets());
       });
 
       runs(function () {
@@ -114,7 +117,8 @@ describe('Target', function() {
     it('should run the default target if no selection has been made', function () {
       waitsForPromise(function () {
         var file = __dirname + '/fixture/.atom-build.targets.json';
-        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json');
+        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json')
+          .then(() => specHelpers.refreshAwaitTargets());
       });
 
       runs(function () {
@@ -134,7 +138,8 @@ describe('Target', function() {
     it('run the selected target if selection has changed, and subsequent build should run that target', function () {
       waitsForPromise(function () {
         var file = __dirname + '/fixture/.atom-build.targets.json';
-        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json');
+        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json')
+          .then(() => specHelpers.refreshAwaitTargets());
       });
 
       runs(function () {

--- a/spec/build-view-spec.js
+++ b/spec/build-view-spec.js
@@ -50,7 +50,10 @@ describe('BuildView', function() {
         cmd: 'printf "\\033[31mHello\\e[0m World"'
       }));
 
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
       waitsFor(function () {
         return workspaceElement.querySelector('.build .title') &&
           workspaceElement.querySelector('.build .title').classList.contains('success');
@@ -66,7 +69,10 @@ describe('BuildView', function() {
         cmd: 'printf "data without linebreak"'
       }));
 
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
       waitsFor(function () {
         return workspaceElement.querySelector('.build .title') &&
           workspaceElement.querySelector('.build .title').classList.contains('success');
@@ -82,7 +88,10 @@ describe('BuildView', function() {
         cmd: 'node -e \'process.stdout.write("same"); setTimeout(function () { process.stdout.write(" line\\n") }, 200);\''
       }));
 
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
       waitsFor(function () {
         return workspaceElement.querySelector('.build .title') &&
           workspaceElement.querySelector('.build .title').classList.contains('success');
@@ -103,7 +112,10 @@ describe('BuildView', function() {
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
         cmd: 'echo "<script type=\"text/javascript\">alert(\'XSS!\')</script>"'
       }));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -124,7 +136,10 @@ describe('BuildView', function() {
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
         cmd: 'echo "Building, this will take some time..." && sleep 30 && echo "Done!"'
       }));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       // Let build run for 1.2 second. This should set the timer at "at least" 1.2
       // which is expected below. If this waits longer than 2000 ms, we're in trouble.
@@ -148,7 +163,10 @@ describe('BuildView', function() {
         cmd: 'echo match1 match1 match1 && exit 1',
         errorMatch: 'match1'
       }));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -173,7 +191,10 @@ describe('BuildView', function() {
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
         cmd: 'echo this will fail && exit 1',
       }));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -194,7 +215,10 @@ describe('BuildView', function() {
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
         cmd: 'echo this will fail && exit 1',
       }));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -215,7 +239,10 @@ describe('BuildView', function() {
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
         cmd: 'echo this will fail && exit 1',
       }));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&
@@ -236,7 +263,10 @@ describe('BuildView', function() {
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
         cmd: 'echo this will fail && exit 1',
       }));
-      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(function() {
         return workspaceElement.querySelector('.build .title') &&

--- a/spec/build-visible-spec.js
+++ b/spec/build-visible-spec.js
@@ -85,7 +85,10 @@ describe('Visible', function() {
         fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
           cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
         }));
-        atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+        waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+        runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
         /* Give it some reasonable time to show itself if there is a bug */
         waits(200);
@@ -124,7 +127,10 @@ describe('Visible', function() {
         fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
           cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
         }));
-        atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+        waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+        runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
         /* Give it some reasonable time to show itself if there is a bug */
         waits(200);
@@ -140,7 +146,10 @@ describe('Visible', function() {
         fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
           cmd: 'echo "Very bad..." && exit 2'
         }));
-        atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+        waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+        runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
         /* Give it some reasonable time to show itself if there is a bug */
         waits(200);
@@ -156,7 +165,10 @@ describe('Visible', function() {
         fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
           cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
         }));
-        atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+        waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+        runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
         waits(200); // Let build finish. Since UI component is not visible yet, there's nothing to poll.
 


### PR DESCRIPTION
Targets (as well as active target) are now cached on a
per project basis. This has several implications:

  * Targets will only be reloaded when root project paths
    are added/removed or when triggered manually. This means
    that selecting active target wont implicitly refresh the
    cache. This improves usability when switching between active
    targets.

  * Working with multiple project roots is now possible without
    re-selecting active targets.

Fixes #179