### PR TITLE
Fixed dependency.

### DIFF
--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -2,7 +2,7 @@
 
 import fs from 'fs';
 import path from 'path';
-import { XRegExp } from 'XRegExp';
+import { XRegExp } from 'xregexp';
 import { EventEmitter } from 'events';
 import GoogleAnalytics from './google-analytics';
 


### PR DESCRIPTION
`package.json` uses `xregexp` as package name, but you use `XRegExp` in your project. Fixed in this file.