### PR TITLE
Remove PATH edit from Package Activation.

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -80,11 +80,6 @@ module.exports = {
   },
 
   activate: function () {
-    // Manually append /usr/local/bin as it may not be set on some systems,
-    // and it's common to have node installed here. Keep it at end so it won't
-    // accidentially override any other node installation
-    process.env.PATH += ':/usr/local/bin';
-
     this.buildView = new BuildView();
 
     this.tools = [ require('./atom-build') ];


### PR DESCRIPTION
This can cause issues on non *nix platforms and it's outside of build's scope.
Users with environment issues should install atom-community's [`environment` package](https://atom.io/packages/environment).