### PR TITLE
add option to toggle if build should fail if error regex matches

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -37,19 +37,26 @@ export default {
       default: false,
       order: 3
     },
+    matchedErrorFailsBuild: {
+      title: 'Any matched error will fail the build',
+      description: 'Even if the build has a return code of zero it is marked as "failed" if any error is being matched in the output.',
+      type: 'boolean',
+      default: true,
+      order: 4
+    },
     scrollOnError: {
       title: 'Automatically scroll on build error',
       description: 'Automatically scroll to first matched error when a build failed.',
       type: 'boolean',
       default: false,
-      order: 4
+      order: 5
     },
     stealFocus: {
       title: 'Steal Focus',
       description: 'Steal focus when opening build panel.',
       type: 'boolean',
       default: true,
-      order: 5
+      order: 6
     },
     monocleHeight: {
       title: 'Monocle Height',
@@ -58,7 +65,7 @@ export default {
       default: 0.75,
       minimum: 0.1,
       maximum: 0.9,
-      order: 6
+      order: 7
     },
     minimizedHeight: {
       title: 'Minimized Height',
@@ -67,7 +74,7 @@ export default {
       default: 0.15,
       minimum: 0.1,
       maximum: 0.9,
-      order: 7
+      order: 8
     },
     panelOrientation: {
       title: 'Panel Orientation',
@@ -75,7 +82,7 @@ export default {
       type: 'string',
       default: 'Bottom',
       enum: [ 'Bottom', 'Top', 'Left', 'Right' ],
-      order: 8
+      order: 9
     }
   },
 
@@ -375,7 +382,10 @@ export default {
       this.child.on('close', (exitCode) => {
         this.errorMatcher.set(target.errorMatch, cwd, this.buildView.output.text());
 
-        const success = (0 === exitCode) && !this.errorMatcher.hasMatch();
+        let success = (0 === exitCode);
+        if (atom.config.get('build.matchedErrorFailsBuild')) {
+          success = success && !this.errorMatcher.hasMatch();
+        }
         this.buildView.buildFinished(success);
         if (success) {
           GoogleAnalytics.sendEvent('build', 'succeeded');


### PR DESCRIPTION
This PR addresses #224. It adds a new option to allow disabling the behavior added in #144. The default value does not change the current behavior.

I added the new option `matchedErrorFailsBuild` after the build trigger options and before the option determining the behavior after the build (scrollOnError).