### PR TITLE
When build failed, show the path

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -382,7 +382,8 @@ export default {
         }
 
         if ('ENOENT' === err.code) {
-          this.buildView.append('Make sure `cmd` and `cwd` exists and have correct access permissions.');
+          this.buildView.append('Make sure `cmd` and `cwd` exists and have correct access permissions.\n');
+          this.buildView.append(`Build finds binaries in these folders: ${process.env.PATH}\n`);
         }
       });
 


### PR DESCRIPTION
Showing the path so it is easier to debug
issues where command is not found.