### PR TITLE
Update specificity of custom keymaps

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -253,8 +253,8 @@ export default {
 
           GoogleAnalytics.sendEvent('keymap', 'registered', setting.keymap);
           const commandName = 'build:trigger:' + setting.name;
-          const keymapSpec = { 'atom-workspace': {} };
-          keymapSpec['atom-workspace'][setting.keymap] = commandName;
+          const keymapSpec = { 'atom-workspace, atom-text-editor': {} };
+          keymapSpec['atom-workspace, atom-text-editor'][setting.keymap] = commandName;
           const keymapDispose = atom.keymaps.add(setting.name, keymapSpec);
           const commandDispose = atom.commands.add('atom-workspace', commandName, this.build.bind(this, 'trigger'));
           settings[index].dispose = () => {


### PR DESCRIPTION
They will now reach the same specificity as the built
in commands. Since they are applied later they will
take precedence. Thus allowing custom keymaps to override
built in keymaps.