### PR TITLE
(partly) cross-platform build specs via cmd (sh:true) for windows

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -357,10 +357,11 @@ export default {
       const exec = this.replace(target.exec, target.env);
       const args = target.args.map(arg => this.replace(arg, target.env));
       const cwd = this.replace(target.cwd, target.env);
+			const isWin = process.platform == 'win32';
 
       this.child = require('child_process').spawn(
-        target.sh ? '/bin/sh' : exec,
-        target.sh ? [ '-c', [ exec ].concat(args).join(' ') ] : args,
+        target.sh ? isWin ? 'cmd' : '/bin/sh' : exec,
+        target.sh ? [ isWin ? '/C' : '-c', [ path.normalize(exec) ].concat(args).join(' ') ] : args,
         { cwd: cwd, env: env }
       );
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -358,10 +358,12 @@ export default {
       const args = target.args.map(arg => this.replace(arg, target.env));
       const cwd = this.replace(target.cwd, target.env);
       const isWin = process.platform === 'win32';
+      const shCmd = isWin ? 'cmd' : '/bin/sh'
+      const shCmdArg = isWin ? '/C' : '-c'
 
       this.child = require('child_process').spawn(
-        target.sh ? ( isWin ? 'cmd' : '/bin/sh' ) : exec,
-        target.sh ? [ isWin ? '/C' : '-c', [ path.normalize(exec) ].concat(args).join(' ') ] : args,
+        target.sh ? shCmd : exec,
+        target.sh ? [ shCmdArg, [ path.normalize(exec) ].concat(args).join(' ') ] : args,
         { cwd: cwd, env: env }
       );
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -358,8 +358,8 @@ export default {
       const args = target.args.map(arg => this.replace(arg, target.env));
       const cwd = this.replace(target.cwd, target.env);
       const isWin = process.platform === 'win32';
-      const shCmd = isWin ? 'cmd' : '/bin/sh'
-      const shCmdArg = isWin ? '/C' : '-c'
+      const shCmd = isWin ? 'cmd' : '/bin/sh';
+      const shCmdArg = isWin ? '/C' : '-c';
 
       this.child = require('child_process').spawn(
         target.sh ? shCmd : exec,


### PR DESCRIPTION
(partly) because arguments might still depend on the platform (windows path separators). Since this is less an issue with node processes, this enhancement can still be valuable.