### PR TITLE
Fix blinking keymap testcase

### DIFF
--- a/spec/build-keymap-spec.js
+++ b/spec/build-keymap-spec.js
@@ -166,7 +166,6 @@ describe('Keymap', () => {
 
       runs(() => {
         expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/default/);
-        atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
       });
 
       waitsFor(() => {


### PR DESCRIPTION
If the build is slow, and/or build package closes the build
panel due to its timeout, the toggle panel will really open
the panel - causing the testcase to fail. Defer to always letting
the panel be auto-closed and just wait for it to be closed.