### PR TITLE
Allow specify the default active target

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Option       | Required       | Description
 `errorMatch` | *[optional]*   | A (list of) regular expressions to match output to a file, row and col. See [Error matching](#error-match) for details.
 `keymap`     | *[optional]*   | A keymap string as defined by [`Atom`](https://atom.io/docs/latest/behind-atom-keymaps-in-depth). Pressing this key combination will trigger the target. Examples: `ctrl-alt-k` or `cmd-U`.
 `targets`    | *[optional]*   | Additional targets which can be used to build variations of your project.
+`active`     | *[optional]*   | If you want current target to be the default active one, set this to be `true`. You should only specify one active target.
 
 #### Replacements
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -287,8 +287,10 @@ export default {
         ));
 
         if (_.isNull(this.activeTarget[p]) || !settings.find(s => s.name === this.activeTarget[p])) {
-          /* Active target has been removed or not set. Set it to the highest prio target */
-          this.activeTarget[p] = settings[0] ? settings[0].name : undefined;
+          /* Active target has been removed or not set. Set it to the one with `active` set to true and/or with highest prio target */
+          let actives = settings.filter(target=>target.active);
+          actives = actives.length > 0 ? actives : settings;
+          this.activeTarget[p] = actives[0] ? actives[0].name : undefined;
         }
 
         this.targets[p].forEach(target => target.dispose());


### PR DESCRIPTION
Allow specify the default active target rather than the first one or top level one.

As discussed in #262.