### PR TITLE
Add posibility to use an atom-build config file from the user's home

### DIFF
--- a/lib/atom-build.js
+++ b/lib/atom-build.js
@@ -6,6 +6,7 @@ import _ from 'lodash';
 import CSON from 'cson-parser';
 import yaml from 'js-yaml';
 import EventEmitter from 'events';
+import os from 'os';
 
 function getConfig(file) {
   const realFile = fs.realpathSync(file);
@@ -52,9 +53,14 @@ export default class CustomFile extends EventEmitter {
   }
 
   isEligible() {
-    this.files = [ '.atom-build.json', '.atom-build.cson', '.atom-build.yml' ]
-      .map(file => path.join(this.cwd, file))
-      .filter(fs.existsSync);
+    this.files = [
+      path.join(this.cwd, '.atom-build.json'),
+      path.join(this.cwd, '.atom-build.cson'),
+      path.join(this.cwd, '.atom-build.yml'),
+      path.join(os.homedir(), '.atom-build.json'),
+      path.join(os.homedir(), '.atom-build.cson'),
+      path.join(os.homedir(), '.atom-build.yml')
+    ].filter(fs.existsSync);
     return 0 < this.files.length;
   }
 

--- a/spec/build-atomCommandName-spec.js
+++ b/spec/build-atomCommandName-spec.js
@@ -3,14 +3,18 @@
 import fs from 'fs-extra';
 import temp from 'temp';
 import specHelpers from 'atom-build-spec-helpers';
+import os from 'os';
 
 describe('AtomCommandName', () => {
+  const originalHomedirFn = os.homedir;
   let directory = null;
   let workspaceElement = null;
 
   temp.track();
 
   beforeEach(() => {
+    const createdHomeDir = temp.mkdirSync('atom-build-spec-home');
+    os.homedir = () => createdHomeDir;
     directory = fs.realpathSync(temp.mkdirSync({ prefix: 'atom-build-spec-' }));
     atom.project.setPaths([ directory ]);
 
@@ -33,6 +37,7 @@ describe('AtomCommandName', () => {
   });
 
   afterEach(() => {
+    os.homedir = originalHomedirFn;
     fs.removeSync(directory);
   });
 

--- a/spec/build-confirm-spec.js
+++ b/spec/build-confirm-spec.js
@@ -4,16 +4,20 @@ import _ from 'lodash';
 import fs from 'fs-extra';
 import temp from 'temp';
 import specHelpers from 'atom-build-spec-helpers';
+import os from 'os';
 
 describe('Confirm', () => {
   let directory = null;
   let workspaceElement = null;
   const cat = process.platform === 'win32' ? 'type' : 'cat';
   const waitTime = process.env.CI ? 2400 : 200;
+  const originalHomedirFn = os.homedir;
 
   temp.track();
 
   beforeEach(() => {
+    const createdHomeDir = temp.mkdirSync('atom-build-spec-home');
+    os.homedir = () => createdHomeDir;
     directory = fs.realpathSync(temp.mkdirSync({ prefix: 'atom-build-spec-' })) + '/';
     atom.project.setPaths([ directory ]);
 
@@ -37,6 +41,7 @@ describe('Confirm', () => {
 
   afterEach(() => {
     fs.removeSync(directory);
+    os.homedir = originalHomedirFn;
   });
 
   describe('when the text editor is modified', () => {

--- a/spec/build-error-match-spec.js
+++ b/spec/build-error-match-spec.js
@@ -4,6 +4,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import temp from 'temp';
 import specHelpers from 'atom-build-spec-helpers';
+import os from 'os';
 
 describe('Error Match', () => {
   const errorMatchAtomBuildFile = __dirname + '/fixture/.atom-build.error-match.json';
@@ -13,6 +14,7 @@ describe('Error Match', () => {
   const errorMatchMultiFirstAtomBuildFile = __dirname + '/fixture/.atom-build.error-match-multiple-first.json';
   const errorMatchLongOutputAtomBuildFile = __dirname + '/fixture/.atom-build.error-match-long-output.json';
   const errorMatchMultiMatcherAtomBuildFile = __dirname + '/fixture/.atom-build.error-match-multiple-errorMatch.json';
+  const originalHomedirFn = os.homedir;
 
   let directory = null;
   let workspaceElement = null;
@@ -21,6 +23,8 @@ describe('Error Match', () => {
   temp.track();
 
   beforeEach(() => {
+    const createdHomeDir = temp.mkdirSync('atom-build-spec-home');
+    os.homedir = () => createdHomeDir;
     directory = fs.realpathSync(temp.mkdirSync({ prefix: 'atom-build-spec-' })) + path.sep;
     atom.project.setPaths([ directory ]);
 
@@ -46,6 +50,7 @@ describe('Error Match', () => {
 
   afterEach(() => {
     fs.removeSync(directory);
+    os.homedir = originalHomedirFn;
   });
 
   describe('when error matcher is configured incorrectly', () => {

--- a/spec/build-keymap-spec.js
+++ b/spec/build-keymap-spec.js
@@ -4,14 +4,18 @@ import fs from 'fs-extra';
 import path from 'path';
 import temp from 'temp';
 import specHelpers from 'atom-build-spec-helpers';
+import os from 'os';
 
 describe('Keymap', () => {
+  const originalHomedirFn = os.homedir;
   let directory = null;
   let workspaceElement = null;
 
   temp.track();
 
   beforeEach(() => {
+    const createdHomeDir = temp.mkdirSync('atom-build-spec-home');
+    os.homedir = () => createdHomeDir;
     directory = fs.realpathSync(temp.mkdirSync({ prefix: 'atom-build-spec-' })) + path.sep;
     atom.project.setPaths([ directory ]);
 
@@ -34,6 +38,7 @@ describe('Keymap', () => {
   });
 
   afterEach(() => {
+    os.homedir = originalHomedirFn;
     fs.removeSync(directory);
   });
 

--- a/spec/build-spec.js
+++ b/spec/build-spec.js
@@ -4,6 +4,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import temp from 'temp';
 import specHelpers from 'atom-build-spec-helpers';
+import os from 'os';
 
 describe('Build', () => {
   const goodAtomBuildfile = __dirname + '/fixture/.atom-build.json';
@@ -13,6 +14,7 @@ describe('Build', () => {
   const shTrueAtomBuildFile = __dirname + '/fixture/.atom-build.sh-true.json';
   const shDefaultAtomBuildFile = __dirname + '/fixture/.atom-build.sh-default.json';
   const syntaxErrorAtomBuildFile = __dirname + '/fixture/.atom-build.syntax-error.json';
+  const originalHomedirFn = os.homedir;
 
   let directory = null;
   let workspaceElement = null;
@@ -41,6 +43,11 @@ describe('Build', () => {
       }).then( (dir) => {
         directory = dir + path.sep;
         atom.project.setPaths([ directory ]);
+        return specHelpers.vouch(temp.mkdir, 'atom-build-spec-home');
+      }).then( (dir) => {
+        return specHelpers.vouch(fs.realpath, dir);
+      }).then( (dir) => {
+        os.homedir = () => dir;
         return atom.packages.activatePackage('build');
       });
     });
@@ -48,6 +55,7 @@ describe('Build', () => {
 
   afterEach(() => {
     fs.removeSync(directory);
+    os.homedir = originalHomedirFn;
   });
 
   describe('when package is activated', () => {

--- a/spec/build-targets-spec.js
+++ b/spec/build-targets-spec.js
@@ -4,8 +4,10 @@ import _ from 'lodash';
 import fs from 'fs-extra';
 import temp from 'temp';
 import specHelpers from 'atom-build-spec-helpers';
+import os from 'os';
 
 describe('Target', () => {
+  const originalHomedirFn = os.homedir;
   let directory = null;
   let workspaceElement = null;
 
@@ -29,12 +31,18 @@ describe('Target', () => {
       }).then((dir) => {
         directory = dir + '/';
         atom.project.setPaths([ directory ]);
+        return specHelpers.vouch(temp.mkdir, 'atom-build-spec-home');
+      }).then( (dir) => {
+        return specHelpers.vouch(fs.realpath, dir);
+      }).then( (dir) => {
+        os.homedir = () => dir;
         return atom.packages.activatePackage('build');
       });
     });
   });
 
   afterEach(() => {
+    os.homedir = originalHomedirFn;
     fs.removeSync(directory);
   });
 

--- a/spec/build-view-spec.js
+++ b/spec/build-view-spec.js
@@ -3,8 +3,10 @@
 import fs from 'fs-extra';
 import temp from 'temp';
 import specHelpers from 'atom-build-spec-helpers';
+import os from 'os';
 
 describe('BuildView', () => {
+  const originalHomedirFn = os.homedir;
   let directory = null;
   let workspaceElement = null;
   const sleep = (duration) => process.platform === 'win32' ? `ping 127.0.0.1 -n ${duration} > NUL` : `sleep ${duration}`;
@@ -35,12 +37,18 @@ describe('BuildView', () => {
       }).then( (dir) => {
         directory = dir + '/';
         atom.project.setPaths([ directory ]);
+        return specHelpers.vouch(temp.mkdir, 'atom-build-spec-home');
+      }).then( (dir) => {
+        return specHelpers.vouch(fs.realpath, dir);
+      }).then( (dir) => {
+        os.homedir = () => dir;
         return atom.packages.activatePackage('build');
       });
     });
   });
 
   afterEach(() => {
+    os.homedir = originalHomedirFn;
     fs.removeSync(directory);
   });
 

--- a/spec/build-visible-spec.js
+++ b/spec/build-visible-spec.js
@@ -3,11 +3,13 @@
 import fs from 'fs-extra';
 import temp from 'temp';
 import specHelpers from 'atom-build-spec-helpers';
+import os from 'os';
 
 describe('Visible', () => {
   let directory = null;
   let workspaceElement = null;
   const waitTime = process.env.CI ? 2400 : 200;
+  const originalHomedirFn = os.homedir;
 
   temp.track();
 
@@ -35,11 +37,17 @@ describe('Visible', () => {
       }).then( (dir) => {
         directory = dir + '/';
         atom.project.setPaths([ directory ]);
+        return specHelpers.vouch(temp.mkdir, 'atom-build-spec-home');
+      }).then( (dir) => {
+        return specHelpers.vouch(fs.realpath, dir);
+      }).then( (dir) => {
+        os.homedir = () => dir;
       });
     });
   });
 
   afterEach(() => {
+    os.homedir = originalHomedirFn;
     fs.removeSync(directory);
   });
 


### PR DESCRIPTION
As discussed on https://github.com/noseglid/atom-build/issues/209

Adding the possibility to use global config files, as a first step, to use the user's home directory looking for any of the supported config file types.

as a bug: the plugin can't watch the whole directory structure, if an atom build file is added to the home directory after the project is loaded, atom build won't recognize the new file, the project needs to be reloaded.

This commit may looks big but tests required lots of modification to support the new "isElegible" method fallback to use user home directory.
