### PR TITLE
Initialize undefined environment variable properly

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -350,7 +350,7 @@ export default {
     }).catch((err) => targetsView.setError(err.message));
   },
 
-  replace(value, targetEnv) {
+  replace(value = '', targetEnv) {
     const env = _.extend({}, process.env, targetEnv);
     value = value.replace(/\$(\w+)/g, function (match, name) {
       return name in env ? env[name] : match;


### PR DESCRIPTION
Fields of `process.env` could be `undefined` in some environment (for example, mine):
![image](https://cloud.githubusercontent.com/assets/922715/11911268/2a52650e-a64b-11e5-98f5-fc2b9f74e3c5.png)

This will cause the following error:
![err](https://cloud.githubusercontent.com/assets/922715/11911271/3ca454e2-a64b-11e5-8abc-9152ecee6503.png)

It can be fixed by simply initializing `replace`'s `value` parameter with empty string by default.