### PR TITLE
Do not throw an error if build config is missing

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -394,7 +394,7 @@ export default {
     targetName = targetName || this.activeTarget[p];
 
     Promise.resolve(this.targets[p]).then(targets => {
-      if (!targets) {
+      if (!targets || 0 === targets.length) {
         throw new BuildError('No eligible build target.', 'No configuration to build this project exists.');
       }
 

--- a/spec/build-spec.js
+++ b/spec/build-spec.js
@@ -434,6 +434,8 @@ describe('Build', () => {
     it('should not attempt to build if buildOnSave is true and no build tool exists', () => {
       atom.config.set('build.buildOnSave', true);
 
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
       waitsForPromise(() => {
         return atom.workspace.open('dummy');
       });


### PR DESCRIPTION
Also updated test which tested for this condititon,
however - the bug only occured after targets where
refreshed, which they didn't have time for in the
test.

Fixes #269