### PR TITLE
Option to hide notifications

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -7,6 +7,7 @@ import { Disposable } from 'atom';
 import kill from 'tree-kill';
 import Grim from 'grim';
 
+import config from './config';
 import SaveConfirmView from './save-confirm-view';
 import StatusBarView from './status-bar-view';
 import TargetsView from './targets-view';
@@ -18,99 +19,7 @@ import CustomFile from './atom-build';
 import providerLegacy from './provider-legacy';
 
 export default {
-  config: {
-    panelVisibility: {
-      title: 'Panel Visibility',
-      description: 'Set when the build panel should be visible.',
-      type: 'string',
-      default: 'Toggle',
-      enum: [ 'Toggle', 'Keep Visible', 'Show on Error', 'Hidden' ],
-      order: 1
-    },
-    buildOnSave: {
-      title: 'Automatically build on save',
-      description: 'Automatically build your project each time an editor is saved.',
-      type: 'boolean',
-      default: false,
-      order: 2
-    },
-    saveOnBuild: {
-      title: 'Automatically save on build',
-      description: 'Automatically save all edited files when triggering a build.',
-      type: 'boolean',
-      default: false,
-      order: 3
-    },
-    matchedErrorFailsBuild: {
-      title: 'Any matched error will fail the build',
-      description: 'Even if the build has a return code of zero it is marked as "failed" if any error is being matched in the output.',
-      type: 'boolean',
-      default: true,
-      order: 4
-    },
-    scrollOnError: {
-      title: 'Automatically scroll on build error',
-      description: 'Automatically scroll to first matched error when a build failed.',
-      type: 'boolean',
-      default: false,
-      order: 5
-    },
-    stealFocus: {
-      title: 'Steal Focus',
-      description: 'Steal focus when opening build panel.',
-      type: 'boolean',
-      default: true,
-      order: 6
-    },
-    selectTriggers: {
-      title: 'Selecting new target triggers the build',
-      description: 'When selecting a new target (through status-bar, cmd-alt-t, etc), the newly selected target will be triggered.',
-      type: 'boolean',
-      default: true,
-      order: 7
-    },
-    monocleHeight: {
-      title: 'Monocle Height',
-      description: 'How much of the workspace to use for build panel when it is "maximized".',
-      type: 'number',
-      default: 0.75,
-      minimum: 0.1,
-      maximum: 0.9,
-      order: 8
-    },
-    minimizedHeight: {
-      title: 'Minimized Height',
-      description: 'How much of the workspace to use for build panel when it is "minimized".',
-      type: 'number',
-      default: 0.15,
-      minimum: 0.1,
-      maximum: 0.9,
-      order: 9
-    },
-    panelOrientation: {
-      title: 'Panel Orientation',
-      description: 'Where to attach the build panel',
-      type: 'string',
-      default: 'Bottom',
-      enum: [ 'Bottom', 'Top', 'Left', 'Right' ],
-      order: 10
-    },
-    statusBar: {
-      title: 'Status Bar',
-      description: 'Where to place the status bar. Set to `Disable` to disable status bar display.',
-      type: 'string',
-      default: 'Left',
-      enum: [ 'Left', 'Right', 'Disable' ],
-      order: 11
-    },
-    statusBarPriority: {
-      title: 'Priority on Status Bar',
-      description: 'Lower priority tiles are placed further to the left/right, depends on where you choose to place Status Bar.',
-      type: 'number',
-      default: -1000,
-      order: 12
-    }
-  },
+  config: config,
 
   activate() {
     if (!/^win/.test(process.platform)) {
@@ -328,10 +237,12 @@ export default {
         return;
       }
 
-      const rows = refreshPaths.map(p => `${this.targets[p].length} targets at: ${p}`);
-      atom.notifications.addInfo('Build targets parsed.', {
-        detail: rows.join('\n')
-      });
+      if (atom.config.get('build.notificationOnRefresh')) {
+        const rows = refreshPaths.map(p => `${this.targets[p].length} targets at: ${p}`);
+        atom.notifications.addInfo('Build targets parsed.', {
+          detail: rows.join('\n')
+        });
+      }
     });
   },
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,102 @@
+'use babel';
+
+export default {
+  panelVisibility: {
+    title: 'Panel Visibility',
+    description: 'Set when the build panel should be visible.',
+    type: 'string',
+    default: 'Toggle',
+    enum: [ 'Toggle', 'Keep Visible', 'Show on Error', 'Hidden' ],
+    order: 1
+  },
+  buildOnSave: {
+    title: 'Automatically build on save',
+    description: 'Automatically build your project each time an editor is saved.',
+    type: 'boolean',
+    default: false,
+    order: 2
+  },
+  saveOnBuild: {
+    title: 'Automatically save on build',
+    description: 'Automatically save all edited files when triggering a build.',
+    type: 'boolean',
+    default: false,
+    order: 3
+  },
+  matchedErrorFailsBuild: {
+    title: 'Any matched error will fail the build',
+    description: 'Even if the build has a return code of zero it is marked as "failed" if any error is being matched in the output.',
+    type: 'boolean',
+    default: true,
+    order: 4
+  },
+  scrollOnError: {
+    title: 'Automatically scroll on build error',
+    description: 'Automatically scroll to first matched error when a build failed.',
+    type: 'boolean',
+    default: false,
+    order: 5
+  },
+  stealFocus: {
+    title: 'Steal Focus',
+    description: 'Steal focus when opening build panel.',
+    type: 'boolean',
+    default: true,
+    order: 6
+  },
+  selectTriggers: {
+    title: 'Selecting new target triggers the build',
+    description: 'When selecting a new target (through status-bar, cmd-alt-t, etc), the newly selected target will be triggered.',
+    type: 'boolean',
+    default: true,
+    order: 7
+  },
+  notificationOnRefresh: {
+    title: 'Show notification when targets are refreshed',
+    description: 'When targets are refreshed a notification with information about the number of targets will be displayed.',
+    type: 'boolean',
+    default: false,
+    order: 8
+  },
+  monocleHeight: {
+    title: 'Monocle Height',
+    description: 'How much of the workspace to use for build panel when it is "maximized".',
+    type: 'number',
+    default: 0.75,
+    minimum: 0.1,
+    maximum: 0.9,
+    order: 9
+  },
+  minimizedHeight: {
+    title: 'Minimized Height',
+    description: 'How much of the workspace to use for build panel when it is "minimized".',
+    type: 'number',
+    default: 0.15,
+    minimum: 0.1,
+    maximum: 0.9,
+    order: 10
+  },
+  panelOrientation: {
+    title: 'Panel Orientation',
+    description: 'Where to attach the build panel',
+    type: 'string',
+    default: 'Bottom',
+    enum: [ 'Bottom', 'Top', 'Left', 'Right' ],
+    order: 11
+  },
+  statusBar: {
+    title: 'Status Bar',
+    description: 'Where to place the status bar. Set to `Disable` to disable status bar display.',
+    type: 'string',
+    default: 'Left',
+    enum: [ 'Left', 'Right', 'Disable' ],
+    order: 12
+  },
+  statusBarPriority: {
+    title: 'Priority on Status Bar',
+    description: 'Lower priority tiles are placed further to the left/right, depends on where you choose to place Status Bar.',
+    type: 'number',
+    default: -1000,
+    order: 13
+  }
+};

--- a/spec/build-confirm-spec.js
+++ b/spec/build-confirm-spec.js
@@ -18,6 +18,7 @@ describe('Confirm', () => {
     atom.config.set('build.buildOnSave', false);
     atom.config.set('build.panelVisibility', 'Toggle');
     atom.config.set('build.saveOnBuild', false);
+    atom.config.set('build.notificationOnRefresh', true);
 
     jasmine.unspy(window, 'setTimeout');
     jasmine.unspy(window, 'clearTimeout');

--- a/spec/build-error-match-spec.js
+++ b/spec/build-error-match-spec.js
@@ -26,6 +26,7 @@ describe('Error Match', () => {
     atom.config.set('build.panelVisibility', 'Toggle');
     atom.config.set('build.saveOnBuild', false);
     atom.config.set('build.scrollOnError', false);
+    atom.config.set('build.notificationOnRefresh', true);
     atom.notifications.clear();
 
     jasmine.unspy(window, 'setTimeout');

--- a/spec/build-keymap-spec.js
+++ b/spec/build-keymap-spec.js
@@ -17,6 +17,7 @@ describe('Keymap', () => {
     atom.config.set('build.buildOnSave', false);
     atom.config.set('build.panelVisibility', 'Toggle');
     atom.config.set('build.saveOnBuild', false);
+    atom.config.set('build.notificationOnRefresh', true);
 
     jasmine.unspy(window, 'setTimeout');
     jasmine.unspy(window, 'clearTimeout');

--- a/spec/build-spec.js
+++ b/spec/build-spec.js
@@ -23,6 +23,7 @@ describe('Build', () => {
     atom.config.set('build.panelVisibility', 'Toggle');
     atom.config.set('build.saveOnBuild', false);
     atom.config.set('build.stealFocus', true);
+    atom.config.set('build.notificationOnRefresh', true);
     atom.notifications.clear();
 
     workspaceElement = atom.views.getView(atom.workspace);

--- a/spec/build-targets-spec.js
+++ b/spec/build-targets-spec.js
@@ -17,6 +17,7 @@ describe('Target', () => {
     atom.config.set('build.buildOnSave', false);
     atom.config.set('build.panelVisibility', 'Toggle');
     atom.config.set('build.saveOnBuild', false);
+    atom.config.set('build.notificationOnRefresh', true);
 
     jasmine.unspy(window, 'setTimeout');
     jasmine.unspy(window, 'clearTimeout');

--- a/spec/build-view-spec.js
+++ b/spec/build-view-spec.js
@@ -15,6 +15,7 @@ describe('BuildView', () => {
     atom.config.set('build.panelVisibility', 'Toggle');
     atom.config.set('build.saveOnBuild', false);
     atom.config.set('build.stealFocus', true);
+    atom.config.set('build.notificationOnRefresh', true);
     atom.notifications.clear();
 
     workspaceElement = atom.views.getView(atom.workspace);

--- a/spec/build-visible-spec.js
+++ b/spec/build-visible-spec.js
@@ -15,6 +15,7 @@ describe('Visible', () => {
     atom.config.set('build.panelVisibility', 'Toggle');
     atom.config.set('build.saveOnBuild', false);
     atom.config.set('build.stealFocus', true);
+    atom.config.set('build.notificationOnRefresh', true);
     atom.notifications.clear();
 
     workspaceElement = atom.views.getView(atom.workspace);


### PR DESCRIPTION
The refreshed targets notifications can be quite intrusive.
Provide an option for disabling them.

Fixes #284 