### PR TITLE
Fill an open target list once loaded

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -228,6 +228,7 @@ export default {
 
         this.targets[p] = settings;
         this.targetsLoading[p] = false;
+        this.fillTargets();
         this.updateStatusBar();
       });
     });
@@ -246,18 +247,24 @@ export default {
     });
   },
 
+  fillTargets() {
+    if (this.targetsView) {
+      const p = this.activePath();
+      this.targetsView.setActiveTarget(this.activeTarget[p]);
+      this.targetsView.setItems((this.targets[p] || []).map(target => target.name));
+    }
+  },
+
   selectActiveTarget() {
     const p = this.activePath();
-    const targets = this.targets[p];
-    const targetsView = new TargetsView();
+    this.targetsView = new TargetsView();
 
     if (this.targetsLoading[p]) {
-      return targetsView.setLoading('Loading project build targets\u2026');
+      return this.targetsView.setLoading('Loading project build targets\u2026');
     }
 
-    targetsView.setActiveTarget(this.activeTarget[p]);
-    targetsView.setItems((targets || []).map(target => target.name));
-    targetsView.awaitSelection().then((newTarget) => {
+    this.fillTargets();
+    this.targetsView.awaitSelection().then((newTarget) => {
       this.activeTarget[p] = newTarget;
       this.updateStatusBar();
 
@@ -265,7 +272,11 @@ export default {
         const workspaceElement = atom.views.getView(atom.workspace);
         atom.commands.dispatch(workspaceElement, 'build:trigger');
       }
-    }).catch((err) => targetsView.setError(err.message));
+      this.targetsView = null;
+    }).catch((err) => {
+      this.targetsView = null;
+      this.targetsView.setError(err.message);
+    });
   },
 
   replace(value = '', targetEnv) {


### PR DESCRIPTION
If the targets list has been open, it is now required to
re-open it once the targets-loading has finished.
This fixes that so items are added to the existing list.