### PR TITLE
Register target commands regardless of keymap existence

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -3,7 +3,7 @@
 import fs from 'fs';
 import path from 'path';
 import _ from 'lodash';
-import { Disposable } from 'atom';
+import { Disposable, CompositeDisposable } from 'atom';
 import kill from 'tree-kill';
 import Grim from 'grim';
 
@@ -210,20 +210,21 @@ export default {
         this.targets[p].forEach(target => target.dispose());
 
         settings.forEach((setting, index) => {
-          if (!setting.keymap) {
-            return;
+          const subscriptions = new CompositeDisposable();
+
+          const commandName = 'build:trigger:' + setting.name;
+          subscriptions.add(atom.commands.add(
+            'atom-workspace', commandName, this.build.bind(this, 'trigger')
+          ));
+
+          if (setting.keymap) {
+            GoogleAnalytics.sendEvent('keymap', 'registered', setting.keymap);
+            const keymapSpec = { 'atom-workspace, atom-text-editor': {} };
+            keymapSpec['atom-workspace, atom-text-editor'][setting.keymap] = commandName;
+            subscriptions.add(atom.keymaps.add(setting.name, keymapSpec));
           }
 
-          GoogleAnalytics.sendEvent('keymap', 'registered', setting.keymap);
-          const commandName = 'build:trigger:' + setting.name;
-          const keymapSpec = { 'atom-workspace, atom-text-editor': {} };
-          keymapSpec['atom-workspace, atom-text-editor'][setting.keymap] = commandName;
-          const keymapDispose = atom.keymaps.add(setting.name, keymapSpec);
-          const commandDispose = atom.commands.add('atom-workspace', commandName, this.build.bind(this, 'trigger'));
-          settings[index].dispose = () => {
-            keymapDispose.dispose();
-            commandDispose.dispose();
-          };
+          settings[index].dispose = () => subscriptions.dispose();
         });
 
         this.targets[p] = settings;


### PR DESCRIPTION
Commands like `build:trigger:<command name>` were previously registered
only in case when command definition contains keymap.