### PR TITLE
Check if tool.removeAllListeners esists before call

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -95,7 +95,7 @@ export default {
 
   deactivate() {
     _.map(this.instancedTools, (tools, cwd) => tools.forEach(tool => {
-      tool.removeAllListeners('refresh');
+      tool.removeAllListeners && tool.removeAllListeners('refresh');
       tool.destructor && tool.destructor();
     }));
 


### PR DESCRIPTION
Some tools may not have `removeAllListeners` method, especially those
which do not extend `EventEmitter`.

Deactivating this package (Settings > Packages > build > Deactivate) leads to the following error: 

```
Error deactivating package 'build' TypeError: tool.removeAllListeners is not a function
    at /path/to/atom-build/lib/build.js:98:12
    ...
```