### PR TITLE
When build is aborted, update status-bar-view

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -472,7 +472,10 @@ export default {
       if (!this.child.killed) {
         this.buildView.buildAbortInitiated();
       }
-      this.abort(() => this.buildView.buildAborted());
+      this.abort(() => {
+        this.buildView.buildAborted();
+        this.statusBarView && this.statusBarView.buildAborted();
+      });
     } else {
       this.buildView.reset();
     }

--- a/lib/status-bar-view.js
+++ b/lib/status-bar-view.js
@@ -63,6 +63,10 @@ export default class StatusBarView extends View {
     this.setClasses();
   }
 
+  buildAborted() {
+    this.setBuildSuccess(false);
+  }
+
   setBuildSuccess(success) {
     this.success = success;
     this.setClasses(success ? 'status-success icon-check' : 'status-error icon-flame');


### PR DESCRIPTION
This stops the spinning gear, and sets the fire icon.