### PR TITLE
Allow to specify a command name for a target

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -3,7 +3,7 @@
 import fs from 'fs';
 import path from 'path';
 import _ from 'lodash';
-import { Disposable } from 'atom';
+import { Disposable, CompositeDisposable } from 'atom';
 import kill from 'tree-kill';
 import Grim from 'grim';
 
@@ -20,6 +20,7 @@ import providerLegacy from './provider-legacy';
 
 export default {
   config: config,
+  targetsSubscriptions: null,
 
   activate() {
     if (!/^win/.test(process.platform)) {
@@ -139,8 +140,7 @@ export default {
       args: [],
       cwd: cwd,
       sh: true,
-      errorMatch: '',
-      dispose: Function.prototype
+      errorMatch: ''
     };
   },
 
@@ -207,23 +207,26 @@ export default {
           this.activeTarget[p] = settings[0] ? settings[0].name : undefined;
         }
 
-        this.targets[p].forEach(target => target.dispose());
+        // CompositeDisposable cannot be reused, so we must create a new instance on every refresh
+        this.targetsSubscriptions && this.targetsSubscriptions.dispose();
+        this.targetsSubscriptions = new CompositeDisposable();
 
         settings.forEach((setting, index) => {
-          if (!setting.keymap) {
+          if (!setting.atomCommandName) {
             return;
           }
 
-          GoogleAnalytics.sendEvent('keymap', 'registered', setting.keymap);
-          const commandName = 'build:trigger:' + setting.name;
-          const keymapSpec = { 'atom-workspace, atom-text-editor': {} };
-          keymapSpec['atom-workspace, atom-text-editor'][setting.keymap] = commandName;
-          const keymapDispose = atom.keymaps.add(setting.name, keymapSpec);
-          const commandDispose = atom.commands.add('atom-workspace', commandName, this.build.bind(this, 'trigger'));
-          settings[index].dispose = () => {
-            keymapDispose.dispose();
-            commandDispose.dispose();
-          };
+          const subscriptions = new CompositeDisposable();
+          subscriptions.add(atom.commands.add('atom-workspace', setting.atomCommandName, this.build.bind(this, 'trigger')));
+
+          if (setting.keymap) {
+            GoogleAnalytics.sendEvent('keymap', 'registered', setting.keymap);
+            const keymapSpec = { 'atom-workspace, atom-text-editor': {} };
+            keymapSpec['atom-workspace, atom-text-editor'][setting.keymap] = setting.atomCommandName;
+            subscriptions.add(atom.keymaps.add(setting.name, keymapSpec));
+          }
+
+          this.targetsSubscriptions.add(subscriptions);
         });
 
         this.targets[p] = settings;
@@ -311,16 +314,19 @@ export default {
     return value;
   },
 
-  startNewBuild(source, targetName) {
+  startNewBuild(source, atomCommandName) {
     const p = this.activePath();
-    targetName = targetName || this.activeTarget[p];
 
     Promise.resolve(this.targets[p]).then(targets => {
       if (!targets || 0 === targets.length) {
         throw new BuildError('No eligible build target.', 'No configuration to build this project exists.');
       }
 
-      const target = targets.find(t => t.name === targetName);
+      let target = targets.find(t => t.atomCommandName === atomCommandName);
+      if (!target) {
+        const targetName = this.activeTarget[p];
+        target = targets.find(t => t.name === targetName);
+      }
       GoogleAnalytics.sendEvent('build', 'triggered');
 
       if (!target.exec) {
@@ -437,7 +443,7 @@ export default {
     clearTimeout(this.finishedTimer);
 
     this.doSaveConfirm(this.unsavedTextEditors(), () => {
-      const next = this.startNewBuild.bind(this, source, event ? event.type.substr(14) : null);
+      const next = this.startNewBuild.bind(this, source, event ? event.type : null);
       this.child ? this.abort(next) : next();
     });
   },


### PR DESCRIPTION
This PR allows to specify a command name and optionally a keymap. Keymap is ignored, unless a command name is specified!

`startNewBuild` now accepts `atomCommandName` as a second argument. Since command names are now set by users (or provider writers), we cannot use them as a source of target names. `startNewBuild` now uses whole command name to find a target to execute. It uses selected target if target with given command name cannot be found.