### PR TITLE
Use cross-spawn when sh is false for better Windows spawning support

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -347,7 +347,7 @@ export default {
 
       this.child = require('child_process').spawn(
         target.sh ? shCmd : exec,
-        target.sh ? [ shCmdArg, [ path.normalize(exec) ].concat(isWin ? args.map(arg => '"'+arg+'"') : args).join(' ') ] : args,
+        target.sh ? [ shCmdArg, [ path.normalize(exec) ].concat(isWin ? args.map(arg => '"' + arg + '"') : args).join(' ') ] : args,
         { cwd: cwd, env: env, windowsVerbatimArguments: true }
       );
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -343,13 +343,21 @@ export default {
       const cwd = this.replace(target.cwd, target.env);
       const isWin = process.platform === 'win32';
       const shCmd = isWin ? 'cmd' : '/bin/sh';
-      const shCmdArg = isWin ? '/S/C' : '-c';
+      const shCmdArg = isWin ? '/C' : '-c';
 
-      this.child = require('child_process').spawn(
-        target.sh ? shCmd : exec,
-        target.sh ? [ shCmdArg, [ path.normalize(exec) ].concat(isWin ? args.map(arg => '"' + arg + '"') : args).join(' ') ] : args,
-        { cwd: cwd, env: env, windowsVerbatimArguments: true }
-      );
+      if (target.sh) {
+        this.child = require('child_process').spawn(
+          shCmd,
+          [ shCmdArg, [ path.normalize(exec) ].concat(args).join(" ")],
+          { cwd: cwd, env: env }
+        );
+      } else {
+        this.child = require('cross-spawn-async').spawn(
+          exec,
+          args,
+          { cwd: cwd, env: env }
+        );
+      }
 
       this.stdout = new Buffer(0);
       this.child.stdout.on('data', (buffer) => {

--- a/lib/build.js
+++ b/lib/build.js
@@ -343,12 +343,12 @@ export default {
       const cwd = this.replace(target.cwd, target.env);
       const isWin = process.platform === 'win32';
       const shCmd = isWin ? 'cmd' : '/bin/sh';
-      const shCmdArg = isWin ? '/C' : '-c';
+      const shCmdArg = isWin ? '/S/C' : '-c';
 
       this.child = require('child_process').spawn(
         target.sh ? shCmd : exec,
-        target.sh ? [ shCmdArg, [ path.normalize(exec) ].concat(args).join(' ') ] : args,
-        { cwd: cwd, env: env }
+        target.sh ? [ shCmdArg, [ path.normalize(exec) ].concat(isWin ? args.map(arg => '"'+arg+'"') : args).join(' ') ] : args,
+        { cwd: cwd, env: env, windowsVerbatimArguments: true }
       );
 
       this.stdout = new Buffer(0);

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "ansi_up": "^1.3.0",
     "atom-space-pen-views": "^2.0.3",
-    "cross-spawn": "^2.1.5",
+    "cross-spawn-async": "^2.1.8",
     "cson-parser": "^1.3.0",
     "getmac": "^1.0.7",
     "grim": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "ansi_up": "^1.3.0",
     "atom-space-pen-views": "^2.0.3",
+    "cross-spawn": "^2.1.5",
     "cson-parser": "^1.3.0",
     "getmac": "^1.0.7",
     "grim": "^2.0.0",


### PR DESCRIPTION
This became a much deeper issue than I had first realized! https://github.com/nodejs/node-v0.x-archive/issues/2318 has a lot of information related to the problem I was having.

Specifically, my home folder on Windows has a space in it. FILE_ACTIVE would provide the full path to the file I was building. But node's escaping isn't ideal when it tries to pass that to the Windows cmd executable.

Based on the numerous references to cross-spawn in the issue above, I ended up implementing this by using cross-spawn but only when sh is false. Using it when sh is true broke a ton of use cases in the spec and I'm sure out in the wild that were implemented like this:
`{
  "cmd": "echo Hello World!",
  "sh": true
}`