### PR TITLE
Implement pre-/post-build hooks

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -334,7 +334,7 @@ export default {
       }
 
       return Promise.resolve().then(() => {
-        if (target.preBuild && _.isFunction(target.preBuild)) {
+        if (target.preBuild && typeof target.preBuild === 'function') {
           return target.preBuild();
         }
       }).then(() => target);
@@ -417,7 +417,7 @@ export default {
         }
         this.child = null;
 
-        if (target.postBuild && _.isFunction(target.postBuild)) {
+        if (target.postBuild && typeof target.postBuild === 'function') {
           return target.postBuild(success);
         }
       });

--- a/lib/build.js
+++ b/lib/build.js
@@ -333,6 +333,12 @@ export default {
         throw new BuildError('Invalid build file.', 'No executable command specified.');
       }
 
+      return Promise.resolve().then(() => {
+        if (target.preBuild && _.isFunction(target.preBuild)) {
+          return target.preBuild();
+        }
+      }).then(() => target);
+    }).then(target => {
       const env = _.extend({}, process.env, target.env);
       _.forEach(env, (value, key, list) => {
         list[key] = this.replace(value, target.env);
@@ -410,6 +416,10 @@ export default {
           GoogleAnalytics.sendEvent('build', 'failed');
         }
         this.child = null;
+
+        if (target.postBuild && _.isFunction(target.postBuild)) {
+          return target.postBuild(success);
+        }
       });
 
       this.statusBarView && this.statusBarView.buildStarted();

--- a/spec/build-hooks-spec.js
+++ b/spec/build-hooks-spec.js
@@ -1,0 +1,110 @@
+'use babel';
+
+import fs from 'fs-extra';
+import temp from 'temp';
+import specHelpers from 'atom-build-spec-helpers';
+
+describe('Hooks', () => {
+  let directory = null;
+  let workspaceElement = null;
+  let target = null;
+  const commandName = 'build:hook-test:trigger-build';
+
+  function getBuildModule() {
+    return atom.packages.getLoadedPackage('build').mainModule;
+  }
+
+  temp.track();
+
+  beforeEach(() => {
+    directory = fs.realpathSync(temp.mkdirSync({ prefix: 'atom-build-spec-' }));
+    atom.project.setPaths([ directory ]);
+
+    atom.config.set('build.buildOnSave', false);
+    atom.config.set('build.panelVisibility', 'Toggle');
+    atom.config.set('build.saveOnBuild', false);
+    atom.config.set('build.notificationOnRefresh', true);
+
+    jasmine.unspy(window, 'setTimeout');
+    jasmine.unspy(window, 'clearTimeout');
+
+    runs(() => {
+      workspaceElement = atom.views.getView(atom.workspace);
+      jasmine.attachToDOM(workspaceElement);
+    });
+
+    waitsForPromise(() => {
+      return atom.packages.activatePackage('build');
+    });
+
+    runs(() => {
+      fs.writeFileSync(directory + '/.atom-build.json', fs.readFileSync(__dirname + '/fixture/.atom-build.hooks.json'));
+    });
+
+    waitsForPromise(() => specHelpers.refreshAwaitTargets());
+  });
+
+  afterEach(() => {
+    fs.removeSync(directory);
+  });
+
+  it('should call preBuild', () => {
+    runs(() => {
+      target = getBuildModule().targets[directory].find(t => t.atomCommandName === commandName);
+      target.preBuild = () => {};
+      spyOn(target, 'preBuild');
+
+      atom.commands.dispatch(workspaceElement, commandName);
+    });
+
+    waitsFor(() => {
+      return workspaceElement.querySelector('.build .title');
+    });
+
+    runs(() => {
+      expect(target.preBuild).toHaveBeenCalled();
+    });
+  });
+
+  describe('postBuild', () => {
+    it('should be called with `true` as an argument when build succeded', () => {
+      runs(() => {
+        target = getBuildModule().targets[directory].find(t => t.atomCommandName === commandName);
+        target.postBuild = () => {};
+        spyOn(target, 'postBuild');
+
+        atom.commands.dispatch(workspaceElement, commandName);
+      });
+
+      waitsFor(() => {
+        return workspaceElement.querySelector('.build .title') &&
+          workspaceElement.querySelector('.build .title').classList.contains('success');
+      });
+
+      runs(() => {
+        expect(target.postBuild).toHaveBeenCalledWith(true);
+      });
+    });
+
+    it('should be called with `false` as an argument when build failed', () => {
+      runs(() => {
+        target = getBuildModule().targets[directory].find(t => t.atomCommandName === commandName);
+        target.postBuild = () => {};
+        spyOn(target, 'postBuild');
+
+        target.args = ['1'];
+
+        atom.commands.dispatch(workspaceElement, commandName);
+      });
+
+      waitsFor(() => {
+        return workspaceElement.querySelector('.build .title') &&
+          workspaceElement.querySelector('.build .title').classList.contains('error');
+      });
+
+      runs(() => {
+        expect(target.postBuild).toHaveBeenCalledWith(false);
+      });
+    });
+  });
+});

--- a/spec/fixture/.atom-build.hooks.json
+++ b/spec/fixture/.atom-build.hooks.json
@@ -1,6 +1,0 @@
-{
-  "cmd": "exit",
-  "args": ["0"],
-  "atomCommandName": "build:hook-test:trigger-build",
-  "sh": true
-}

--- a/spec/fixture/.atom-build.hooks.json
+++ b/spec/fixture/.atom-build.hooks.json
@@ -1,0 +1,6 @@
+{
+  "cmd": "exit",
+  "args": ["0"],
+  "atomCommandName": "build:hook-test:trigger-build",
+  "sh": true
+}

--- a/spec/fixture/atom-build-hooks-dummy-package/main.js
+++ b/spec/fixture/atom-build-hooks-dummy-package/main.js
@@ -1,0 +1,41 @@
+'use babel';
+
+const hooks = {
+  preBuild: () => {},
+  postBuild: () => {}
+};
+
+class Builder {
+  getNiceName() {
+    return 'Build with hooks';
+  }
+
+  isEligible() {
+    return true;
+  }
+
+  settings() {
+    return [
+      {
+        exec: 'exit',
+        args: ['0'],
+        atomCommandName: 'build:hook-test:succeding',
+        preBuild: () => hooks.preBuild(),
+        postBuild: (success) => hooks.postBuild(success)
+      },
+      {
+        exec: 'exit',
+        args: ['1'],
+        atomCommandName: 'build:hook-test:failing',
+        preBuild: () => hooks.preBuild(),
+        postBuild: (success) => hooks.postBuild(success)
+      }
+    ];
+  }
+}
+
+module.exports = {
+  activate: () => {},
+  provideBuilder: () => Builder,
+  hooks: hooks
+};

--- a/spec/fixture/atom-build-hooks-dummy-package/package.json
+++ b/spec/fixture/atom-build-hooks-dummy-package/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "atom-build-hooks-dummy-package",
+  "main": "main",
+  "providedServices": {
+    "builder": {
+      "versions": {
+        "2.0.0": "provideBuilder"
+      }
+    }
+  }
+}


### PR DESCRIPTION
If target has the "preBuild" attribute and it is a function, it will be called
before the build. If "preBuild" returns a promise, build will be started after
the promise resolution.

"postBuild" hook is called upon child closed. "postBuild" receives a build
status as an argument.

Such feature is necessary for platformio/platformio-atom-ide/issues/45.