### PR TITLE
Match errors against original child output buffer

### DIFF
--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -231,8 +231,12 @@ export default class BuildView extends View {
     clearTimeout(this.titleTimer);
   }
 
+  getOutputString() {
+    return _.escape(this.buffer.toString('utf8'));
+  }
+
   _render() {
-    let string = _.escape(this.buffer.toString('utf8'));
+    let string = this.getOutputString();
     this.links.forEach((link) => {
       const replaceRegex = new RegExp(_.escapeRegExp(_.escape(link.text)), 'g');
       string = string.replace(replaceRegex, '<a id="' + link.id + '">' + _.escape(link.text) + '</a>');

--- a/lib/build.js
+++ b/lib/build.js
@@ -385,7 +385,7 @@ export default {
       });
 
       this.child.on('close', (exitCode) => {
-        this.errorMatcher.set(target.errorMatch, cwd, this.buildView.output.text());
+        this.errorMatcher.set(target.errorMatch, cwd, this.buildView.getOutputString());
 
         let success = (0 === exitCode);
         if (atom.config.get('build.matchedErrorFailsBuild')) {


### PR DESCRIPTION
This commit fixes issue when matched error contains escape sequences.
Previously errors were matched against buildView.output.text() value, which
only contains plain text. Then matched error should have been replaced with
a link leading to a corresponging file. Link cannot be properly created when
original output buffer contains escape sequences, because escape sequences
are being removed when buffer is converted to HTML and buildView.output.text()
returns clear text only.

Example output:
```
Some text...
\x1B[31msrc/path/to/file.ext:5:7: error description\x1B[0m
```
Error line is red. Currently I can use the following regexp to match this error:
```
"\n(?<file>src[\\/0-9a-zA-Z\\._\\\\]+):(?<line>\\d+):(?<col>\\d+)"
```
This will successfully match the error, but will fail to add a link, because
matched text will be "\nsrc/path/to/file.ext:5:7" when acutally there is an
escape sequence between \n and file path, so link cannot be created.

With this commit I can use the following regexp:
```
"\n\\x1B\\[31m(?<file>src[\\/0-9a-zA-Z\\._\\\\]+):(?<line>\\d+):(?<col>\\d+)"
```
When matched against original buffer, above regexp will find the following text:
```
"\n\x1B[31msrc/path/to/file.ext:5:7"
```
And the link will be properly created.