### PR TITLE
Use Term.JS rather than custom output

### DIFF
--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -1,28 +1,79 @@
 'use babel';
 
-import _ from 'lodash';
 import { View, $ } from 'atom-space-pen-views';
-import ansiUp from 'ansi_up';
 import GoogleAnalytics from './google-analytics';
+import Terminal from 'term.js';
 
 export default class BuildView extends View {
-  constructor() {
-    super(...arguments);
+  constructor(...args) {
+    super(...args);
     this.monocle = false;
     this.starttime = new Date();
-    this.buffer = new Buffer(0);
-    this.links = [];
+    this.terminal = new Terminal({
+      screenKeys: true,
+      convertEol: true,
+      termName: 'xterm-256color'
+    });
+    this.terminal.getContent = function () {
+      return this.lines.reduce((m1, line) => m1 + line.reduce((m2, col) => m2 + col[1], '') + '\n', '');
+    };
+    this.terminal.open(this.output[0]);
+    this.destroyTerminal = ::(this.terminal).destroy;
+    this.terminal.destroy = this.terminal.destroySoon = () => {}; // This terminal will be open forever and reset when necessary
+    this.terminalEl = this.output.find('.terminal');
+    this.terminalEl[0].terminal = this.terminal; // For testing purposes
+
+    this.output[0].addEventListener('transitionend', ::this.resizeTerminal);
+    this.outputWidth = this.output.width();
+    this.outputHeight = this.output.height();
+    setInterval(::this.detectResize, 1000);
 
     this._setMonocleIcon();
 
-    atom.config.observe('build.panelVisibility', this.visibleFromConfig.bind(this));
-    atom.config.observe('build.panelOrientation', this.orientationFromConfig.bind(this));
-    atom.config.observe('build.monocleHeight', this.sizeFromConfig.bind(this));
-    atom.config.observe('build.minimizedHeight', this.sizeFromConfig.bind(this));
-    atom.config.observe('editor.fontFamily', this.fontFromConfig.bind(this));
-    atom.config.observe('editor.fontSize', this.fontFromConfig.bind(this));
+    atom.config.observe('build.panelVisibility', ::this.visibleFromConfig);
+    atom.config.observe('build.panelOrientation', ::this.orientationFromConfig);
+    atom.config.observe('build.monocleHeight', ::this.sizeFromConfig);
+    atom.config.observe('build.minimizedHeight', ::this.sizeFromConfig);
+    atom.config.observe('editor.fontFamily', ::this.fontFromConfig);
+    atom.config.observe('editor.fontSize', ::this.fontFromConfig);
 
-    atom.commands.add('atom-workspace', 'build:toggle-panel', this.toggle.bind(this));
+    atom.commands.add('atom-workspace', 'build:toggle-panel', ::this.toggle);
+  }
+
+  destroy() {
+    this.destroyTerminal();
+  }
+
+  detectResize() {
+    if (!this.isAttached()) {
+      return;
+    }
+    if (this.outputWidth !== this.output.width() || this.outputHeight !== this.output.height()) {
+      this.resizeTerminal();
+      this.outputWidth = this.output.width();
+      this.outputHeight = this.output.height();
+    }
+  }
+
+  getFontGeometry() {
+    const o = $('<div>A</div>')
+      .addClass('terminal')
+      .addClass('terminal-test')
+      .appendTo(this.output);
+    const w = o[0].getBoundingClientRect().width;
+    const h = o[0].getBoundingClientRect().height;
+    o.remove();
+    return { w: w, h: h};
+  }
+
+  resizeTerminal() {
+    const { w, h } = this.getFontGeometry();
+    this.terminal.resize(Math.floor((this.output.width() - 6) / w), Math.floor((this.output.height() - 6) / h)); // -6 for border of terminal
+    this.terminal.refresh(0, this.terminal.rows - 1);
+  }
+
+  getContent() {
+    return this.terminal.getContent();
   }
 
   static initialTimerText() {
@@ -31,7 +82,7 @@ export default class BuildView extends View {
 
   static content() {
     this.div({ tabIndex: -1, class: 'build tool-panel panel-bottom native-key-bindings' }, () => {
-      this.div({ class: 'control-container pull-right opaque-hover' }, () => {
+      this.div({ class: 'control-container opaque-hover' }, () => {
         this.button({ class: 'btn btn-default icon icon-x', click: 'close' });
         this.button({ class: 'btn btn-default icon icon-chevron-up', outlet: 'monocleButton', click: 'toggleMonocle' });
         this.button({ class: 'btn btn-default icon icon-trashcan new-row', click: 'clearOutput' });
@@ -42,6 +93,7 @@ export default class BuildView extends View {
         });
       });
 
+      this.div({ class: 'panel-heading', outlet: 'heading' });
       this.div({ class: 'output panel-body', outlet: 'output' });
     });
   }
@@ -68,7 +120,7 @@ export default class BuildView extends View {
     this.panel = addfn[orientation].call(atom.workspace, { item: this });
     this.sizeFromConfig();
     this.fontFromConfig();
-    this.output.scrollTop(this.output[0].scrollHeight);
+    this.resizeTerminal();
   }
 
   detach(force) {
@@ -99,7 +151,7 @@ export default class BuildView extends View {
     switch (val) {
       case 'Toggle':
       case 'Show on Error':
-        if (!this.title.hasClass('error')) {
+        if (!this.terminalEl.hasClass('error')) {
           this.detach();
         }
         break;
@@ -111,19 +163,19 @@ export default class BuildView extends View {
     this.detach(true);
     if (isVisible) {
       this.attach();
-      this._setMonocleIcon();
     }
+    this._setMonocleIcon();
   }
 
   reset() {
     clearTimeout(this.titleTimer);
     this.buildTimer.text(BuildView.initialTimerText());
     this.titleTimer = 0;
-    this.clearOutput();
+    this.terminal.reset();
 
-    this.title.removeClass('success error');
     this.gear.removeClass('spin spin-flash');
-    this.removeClass('success error');
+    this.heading.removeClass('success error');
+    this.title.removeClass('success error');
 
     this.detach();
   }
@@ -143,9 +195,7 @@ export default class BuildView extends View {
   }
 
   clearOutput() {
-    this.buffer = new Buffer(0);
-    this.links = [];
-    this.output.empty();
+    this.terminal.reset();
   }
 
   build() {
@@ -198,6 +248,9 @@ export default class BuildView extends View {
     this._setMonocleIcon();
   }
 
+  setHeading(heading) {
+    this.heading.text(heading);
+  }
   buildStarted() {
     this.starttime = new Date();
     this.reset();
@@ -226,49 +279,29 @@ export default class BuildView extends View {
 
   finalizeBuild(success) {
     this.title.addClass(success ? 'success' : 'error');
-    this.addClass(success ? 'success' : 'error');
+    this.heading.addClass(success ? 'success' : 'error');
     this.gear.removeClass('spin spin-flash');
     clearTimeout(this.titleTimer);
   }
 
-  _render() {
-    let string = _.escape(this.buffer.toString('utf8'));
-    this.links.forEach((link) => {
-      const replaceRegex = new RegExp(_.escapeRegExp(_.escape(link.text)), 'g');
-      string = string.replace(replaceRegex, '<a id="' + link.id + '">' + _.escape(link.text) + '</a>');
-    });
-    this.output.html(ansiUp.ansi_to_html(string));
-    this.output.find('a').on('click', (event) => {
-      this.links.find(l => l.id === event.currentTarget.id).onClick();
-    });
-  }
-
-  append(data) {
-    const shouldScroll = (this.output[0].scrollHeight - this.output[0].scrollTop === this.output[0].offsetHeight);
-    this.buffer = Buffer.concat([ this.buffer, Buffer.isBuffer(data) ? data : new Buffer(data) ]);
-    this._render();
-    if (shouldScroll) {
-      this.output.scrollTop(this.output[0].scrollHeight);
+  scrollTo(text) {
+    const content = this.getContent();
+    let endPos = -1;
+    let curPos = text.length;
+    // We need to decrese the size of `text` until we find a match. This is because
+    // terminal will insert line breaks ('\r\n') when width of terminal is reached.
+    // It may have been that the middle of a matched error is on a line break.
+    while (-1 === endPos && curPos > 0) {
+      endPos = content.indexOf(text.substring(0, curPos--));
     }
-  }
 
-  link(text, id, onClick) {
-    if (this.links.find(l => l.text === text)) {
+    if (curPos === 0) {
+      // No match - which is weird. Oh well - rather be defensive
       return;
     }
 
-    this.links.push({
-      id: id,
-      text: text,
-      onClick: onClick
-    });
-    this._render();
-  }
-
-  scrollTo(id) {
-    const position = this.output.find('#' + id).position();
-    if (position) {
-      this.output.scrollTop(position.top + this.output.scrollTop());
-    }
+    const row = content.slice(0, endPos).split('\n').length;
+    this.terminal.ydisp = 0;
+    this.terminal.scrollDisp(row - 1);
   }
 }

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -16,7 +16,9 @@ export default class BuildView extends View {
       termName: 'xterm-256color'
     });
     this.terminal.getContent = function () {
-      return this.lines.reduce((m1, line) => m1 + line.reduce((m2, col) => m2 + col[1], '') + '\n', '');
+      return this.lines.reduce((m1, line) => {
+        return m1 + line.reduce((m2, col) => m2 + col[1], '') + '\n';
+      }, '');
     };
     this.terminal.open(this.output[0]);
     this.destroyTerminal = ::(this.terminal).destroy;
@@ -27,7 +29,7 @@ export default class BuildView extends View {
     this.output[0].addEventListener('transitionend', ::this.resizeTerminal);
     this.outputWidth = this.output.width();
     this.outputHeight = this.output.height();
-    setInterval(::this.detectResize, 1000);
+    this.detectResizeInterval = setInterval(::this.detectResize, 1000);
 
     this._setMonocleIcon();
     this.setHeading('Atom build');
@@ -44,6 +46,7 @@ export default class BuildView extends View {
 
   destroy() {
     this.destroyTerminal();
+    clearInterval(this.detectResizeInterval);
   }
 
   detectResize() {
@@ -71,7 +74,6 @@ export default class BuildView extends View {
   resizeTerminal() {
     const { w, h } = this.getFontGeometry();
     this.terminal.resize(Math.floor((this.output.width() - 6) / w), Math.floor((this.output.height() - 6) / h)); // -6 for border of terminal
-    this.terminal.refresh(0, this.terminal.rows - 1);
   }
 
   getContent() {

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -10,8 +10,9 @@ export default class BuildView extends View {
     this.monocle = false;
     this.starttime = new Date();
     this.terminal = new Terminal({
-      screenKeys: true,
+      cursorBlink: false,
       convertEol: true,
+      useFocus: false,
       termName: 'xterm-256color'
     });
     this.terminal.getContent = function () {
@@ -29,6 +30,7 @@ export default class BuildView extends View {
     setInterval(::this.detectResize, 1000);
 
     this._setMonocleIcon();
+    this.setHeading('Atom build');
 
     atom.config.observe('build.panelVisibility', ::this.visibleFromConfig);
     atom.config.observe('build.panelOrientation', ::this.orientationFromConfig);
@@ -82,18 +84,19 @@ export default class BuildView extends View {
 
   static content() {
     this.div({ tabIndex: -1, class: 'build tool-panel panel-bottom native-key-bindings' }, () => {
-      this.div({ class: 'control-container opaque-hover' }, () => {
-        this.button({ class: 'btn btn-default icon icon-x', click: 'close' });
-        this.button({ class: 'btn btn-default icon icon-chevron-up', outlet: 'monocleButton', click: 'toggleMonocle' });
-        this.button({ class: 'btn btn-default icon icon-trashcan new-row', click: 'clearOutput' });
-        this.button({ class: 'btn btn-default icon icon-zap', click: 'build', title: 'Build current project' });
-        this.div({ class: 'title new-row', outlet: 'title' }, () => {
-          this.span({ class: 'icon icon-gear', outlet: 'gear' });
-          this.span({ class: 'build-timer', outlet: 'buildTimer' }, this.initialTimerText());
+      this.div({ class: 'panel-heading', outlet: 'panelHeading' }, () => {
+        this.div({ outlet: 'heading' });
+        this.div({ class: 'control-container opaque-hover' }, () => {
+          this.button({ class: 'btn btn-default icon icon-x', click: 'close' });
+          this.button({ class: 'btn btn-default icon icon-chevron-up', outlet: 'monocleButton', click: 'toggleMonocle' });
+          this.button({ class: 'btn btn-default icon icon-trashcan', click: 'clearOutput' });
+          this.button({ class: 'btn btn-default icon icon-zap', click: 'build', title: 'Build current project' });
+          this.div({ class: 'title', outlet: 'title' }, () => {
+            this.span({ class: 'build-timer', outlet: 'buildTimer' }, this.initialTimerText());
+          });
         });
       });
 
-      this.div({ class: 'panel-heading', outlet: 'heading' });
       this.div({ class: 'output panel-body', outlet: 'output' });
     });
   }
@@ -173,8 +176,7 @@ export default class BuildView extends View {
     this.titleTimer = 0;
     this.terminal.reset();
 
-    this.gear.removeClass('spin spin-flash');
-    this.heading.removeClass('success error');
+    this.panelHeading.removeClass('success error');
     this.title.removeClass('success error');
 
     this.detach();
@@ -251,6 +253,7 @@ export default class BuildView extends View {
   setHeading(heading) {
     this.heading.text(heading);
   }
+
   buildStarted() {
     this.starttime = new Date();
     this.reset();
@@ -258,7 +261,6 @@ export default class BuildView extends View {
     if (atom.config.get('build.stealFocus')) {
       this.focus();
     }
-    this.gear.addClass('spin');
     this.updateTitle();
   }
 
@@ -270,7 +272,6 @@ export default class BuildView extends View {
   }
 
   buildAbortInitiated() {
-    this.gear.removeClass('spin').addClass('spin-flash');
   }
 
   buildAborted() {
@@ -279,8 +280,7 @@ export default class BuildView extends View {
 
   finalizeBuild(success) {
     this.title.addClass(success ? 'success' : 'error');
-    this.heading.addClass(success ? 'success' : 'error');
-    this.gear.removeClass('spin spin-flash');
+    this.panelHeading.addClass(success ? 'success' : 'error');
     clearTimeout(this.titleTimer);
   }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -37,9 +37,6 @@ export default {
     this.activeTarget = {};
     this.targetsLoading = {};
     this.targetsSubscriptions = {};
-
-    this.stdout = new Buffer(0);
-    this.stderr = new Buffer(0);
     this.errorMatcher = new ErrorMatcher();
 
     atom.commands.add('atom-workspace', 'build:refresh-targets', () => this.refreshTargets());
@@ -71,13 +68,8 @@ export default {
       atom.notifications.addError('Error matching failed!', { detail: message });
     });
 
-    this.errorMatcher.on('matched', (id) => {
-      this.buildView.scrollTo(id);
-    });
-
-    this.errorMatcher.on('match', (text, id) => {
-      const callback = this.errorMatcher.goto.bind(this.errorMatcher, id);
-      this.buildView.link(text, id, callback);
+    this.errorMatcher.on('matched', (match) => {
+      this.buildView.scrollTo(match[0]);
     });
 
     atom.packages.onDidActivateInitialPackages(() => this.refreshTargets());
@@ -107,6 +99,7 @@ export default {
     }
 
     this.statusBarView && this.statusBarView.destroy();
+    this.buildView && this.buildView.destroy();
 
     clearTimeout(this.finishedTimer);
   },
@@ -263,10 +256,11 @@ export default {
     this.targetsView = new TargetsView();
 
     if (this.targetsLoading[p]) {
-      return this.targetsView.setLoading('Loading project build targets\u2026');
+      this.targetsView.setLoading('Loading project build targets\u2026');
+    } else {
+      this.fillTargets();
     }
 
-    this.fillTargets();
     this.targetsView.awaitSelection().then((newTarget) => {
       this.activeTarget[p] = newTarget;
       this.updateStatusBar();
@@ -359,33 +353,30 @@ export default {
         );
       }
 
-      this.stdout = new Buffer(0);
-      this.child.stdout.on('data', (buffer) => {
-        this.stdout = Buffer.concat([ this.stdout, buffer ]);
-        this.buildView.append(buffer);
-      });
-
-      this.stderr = new Buffer(0);
-      this.child.stderr.on('data', (buffer) => {
-        this.stderr = Buffer.concat([ this.stderr, buffer ]);
-        this.buildView.append(buffer);
-      });
+      let stdout = '';
+      let stderr = '';
+      this.child.stdout.setEncoding('utf8');
+      this.child.stderr.setEncoding('utf8');
+      this.child.stdout.on('data', d => stdout += d);
+      this.child.stderr.on('data', d => stderr += d);
+      this.child.stdout.pipe(this.buildView.terminal);
+      this.child.stderr.pipe(this.buildView.terminal);
 
       this.child.on('error', (err) => {
-        this.buildView.append((target.sh ? 'Unable to execute with sh: ' : 'Unable to execute: ') + exec + '\n');
+        this.buildView.terminal.write((target.sh ? 'Unable to execute with shell: ' : 'Unable to execute: ') + exec + '\n');
 
         if (/\s/.test(exec) && !target.sh) {
-          this.buildView.append('`cmd` cannot contain space. Use `args` for arguments.\n');
+          this.buildView.terminal.write('`cmd` cannot contain space. Use `args` for arguments.\n');
         }
 
         if ('ENOENT' === err.code) {
-          this.buildView.append('Make sure `cmd` and `cwd` exists and have correct access permissions.\n');
-          this.buildView.append(`Build finds binaries in these folders: ${process.env.PATH}\n`);
+          this.buildView.terminal.write(`Make sure cmd:'${exec}' and cwd:'${cwd}' exists and have correct access permissions.\n`);
+          this.buildView.terminal.write(`Binaries are found in these folders: ${process.env.PATH}\n`);
         }
       });
 
       this.child.on('close', (exitCode) => {
-        this.errorMatcher.set(target.errorMatch, cwd, this.buildView.output.text());
+        this.errorMatcher.set(target.errorMatch, cwd, stdout + stderr);
 
         let success = (0 === exitCode);
         if (atom.config.get('build.matchedErrorFailsBuild')) {
@@ -414,7 +405,7 @@ export default {
 
       this.statusBarView && this.statusBarView.buildStarted();
       this.buildView.buildStarted();
-      this.buildView.append([ (target.sh ? 'Executing with sh:' : 'Executing:'), exec, ...args, '\n'].join(' '));
+      this.buildView.setHeading([ (target.sh ? `${shCmd} ${shCmdArg} ${exec}` : exec ), ...args, '\n'].join(' '));
     }).catch((err) => {
       if (err instanceof BuildError) {
         if (source === 'save') {

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -17,8 +17,8 @@ export default class ErrorMatcher extends EventEmitter {
     this.currentMatch = [];
     this.firstMatchId = null;
 
-    atom.commands.add('atom-workspace', 'build:error-match', this.match.bind(this));
-    atom.commands.add('atom-workspace', 'build:error-match-first', this.matchFirst.bind(this));
+    atom.commands.add('atom-workspace', 'build:error-match', ::this.match);
+    atom.commands.add('atom-workspace', 'build:error-match-first', ::this.matchFirst);
   }
 
   _gotoNext() {
@@ -62,7 +62,7 @@ export default class ErrorMatcher extends EventEmitter {
         initialColumn: col,
         searchAllPanes: true
       });
-      this.emit('matched', match.id);
+      this.emit('matched', match);
     });
   }
 
@@ -80,8 +80,6 @@ export default class ErrorMatcher extends EventEmitter {
     this.currentMatch.sort((a, b) => a.index - b.index);
 
     this.firstMatchId = (this.currentMatch.length > 0) ? this.currentMatch[0].id : null;
-
-    this.currentMatch.forEach(match => this.emit('match', match[0], match.id));
   }
 
   set(regex, cwd, output) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "js-yaml": "^3.4.6",
     "lodash": "^3.8.0",
     "node-uuid": "^1.4.3",
+    "term.js": "0.0.7",
     "tree-kill": "^1.0.0",
     "xregexp": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "js-yaml": "^3.4.6",
     "lodash": "^3.8.0",
     "node-uuid": "^1.4.3",
-    "term.js": "0.0.7",
+    "term.js": "git+https://github.com/jeremyramin/term.js.git#de1635fc2695e7d8165012d3b1d007d7ce60eea2",
     "tree-kill": "^1.0.0",
     "xregexp": "^2.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "atom": ">=0.50.0"
   },
   "dependencies": {
-    "ansi_up": "^1.3.0",
     "atom-space-pen-views": "^2.0.3",
     "cross-spawn-async": "^2.1.8",
     "cson-parser": "^1.3.0",

--- a/spec/build-atomCommandName-spec.js
+++ b/spec/build-atomCommandName-spec.js
@@ -59,7 +59,7 @@ describe('AtomCommandName', () => {
       });
 
       runs(() => {
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/default/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/default/);
         atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
       });
     });

--- a/spec/build-atomCommandName-spec.js
+++ b/spec/build-atomCommandName-spec.js
@@ -28,6 +28,7 @@ describe('AtomCommandName', () => {
 
     runs(() => {
       workspaceElement = atom.views.getView(atom.workspace);
+      workspaceElement.setAttribute('style', 'width:9999px');
       jasmine.attachToDOM(workspaceElement);
     });
 

--- a/spec/build-confirm-spec.js
+++ b/spec/build-confirm-spec.js
@@ -31,6 +31,7 @@ describe('Confirm', () => {
 
     runs(() => {
       workspaceElement = atom.views.getView(atom.workspace);
+      workspaceElement.setAttribute('style', 'width:9999px');
       jasmine.attachToDOM(workspaceElement);
     });
 

--- a/spec/build-confirm-spec.js
+++ b/spec/build-confirm-spec.js
@@ -133,7 +133,7 @@ describe('Confirm', () => {
 
       runs(() => {
         expect(workspaceElement.querySelector('.build')).toExist();
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/Surprising is the passing of time but not so, as the time of passing/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/Surprising is the passing of time but not so, as the time of passing/);
       });
     });
 

--- a/spec/build-error-match-spec.js
+++ b/spec/build-error-match-spec.js
@@ -40,6 +40,7 @@ describe('Error Match', () => {
 
     runs(() => {
       workspaceElement = atom.views.getView(atom.workspace);
+      workspaceElement.setAttribute('style', 'width:9999px');
       jasmine.attachToDOM(workspaceElement);
     });
 

--- a/spec/build-error-match-spec.js
+++ b/spec/build-error-match-spec.js
@@ -198,7 +198,7 @@ describe('Error Match', () => {
         expect(editor.getTitle()).toEqual('.atom-build.json');
         expect(bufferPosition.row).toEqual(2);
         expect(bufferPosition.column).toEqual(7);
-        atom.workspace.getActivePane().destroyActiveItem();
+        atom.workspace.getActivePane().destroy();
       });
 
       runs(() => {
@@ -263,7 +263,7 @@ describe('Error Match', () => {
         expect(editor.getTitle()).toEqual('.atom-build.json');
         expect(bufferPosition.row).toEqual(2);
         expect(bufferPosition.column).toEqual(7);
-        atom.workspace.getActivePane().destroyActiveItem();
+        atom.workspace.getActivePane().destroy();
       });
 
       runs(() => {

--- a/spec/build-error-match-spec.js
+++ b/spec/build-error-match-spec.js
@@ -299,9 +299,9 @@ describe('Error Match', () => {
       });
     });
 
-    it('should open the the file even if tool gives absolute path', () => {
+    it('should open the file even if tool gives absolute path', () => {
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-        cmd: 'echo __' + directory + '.atom-build.json__ && return 1',
+        cmd: 'echo __' + directory + '.atom-build.json__ && exit 1',
         errorMatch: '__(?<file>.+)__'
       }));
 
@@ -421,22 +421,21 @@ describe('Error Match', () => {
       });
 
       waits(waitTime);
-      let firstScrollTop;
       runs(() => {
-        firstScrollTop = workspaceElement.querySelector('.build .output').scrollTop;
+        expect(workspaceElement.querySelector('.terminal').terminal.ydisp).toEqual(6);
         atom.commands.dispatch(workspaceElement, 'build:error-match');
       });
 
       waits(waitTime);
       runs(() => {
-        expect(workspaceElement.querySelector('.build .output').scrollTop).toBeGreaterThan(firstScrollTop);
+        expect(workspaceElement.querySelector('.terminal').terminal.ydisp).toEqual(12);
         atom.commands.dispatch(workspaceElement, 'build:error-match');
       });
 
       waits(waitTime);
       runs(() => {
         /* Should wrap around to first match */
-        expect(workspaceElement.querySelector('.build .output').scrollTop).toEqual(firstScrollTop);
+        expect(workspaceElement.querySelector('.terminal').terminal.ydisp).toEqual(6);
       });
     });
 
@@ -458,21 +457,20 @@ describe('Error Match', () => {
       });
 
       waits(waitTime);
-      let firstScrollTop;
       runs(() => {
-        firstScrollTop = workspaceElement.querySelector('.build .output').scrollTop;
+        expect(workspaceElement.querySelector('.terminal').terminal.ydisp).toEqual(6);
         atom.commands.dispatch(workspaceElement, 'build:error-match');
       });
 
       waits(waitTime);
       runs(() => {
-        expect(workspaceElement.querySelector('.build .output').scrollTop).toBeGreaterThan(firstScrollTop);
+        expect(workspaceElement.querySelector('.terminal').terminal.ydisp).toEqual(12);
         atom.commands.dispatch(workspaceElement, 'build:error-match-first');
       });
 
       waits(waitTime);
       runs(() => {
-        expect(workspaceElement.querySelector('.build .output').scrollTop).toEqual(firstScrollTop);
+        expect(workspaceElement.querySelector('.terminal').terminal.ydisp).toEqual(6);
       });
     });
 

--- a/spec/build-keymap-spec.js
+++ b/spec/build-keymap-spec.js
@@ -65,7 +65,7 @@ describe('Keymap', () => {
       });
 
       runs(() => {
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/default/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/default/);
         atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
       });
 
@@ -83,7 +83,7 @@ describe('Keymap', () => {
       });
 
       runs(() => {
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/keymapped/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/keymapped/);
       });
     });
 
@@ -109,7 +109,7 @@ describe('Keymap', () => {
       });
 
       runs(() => {
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/default/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/default/);
         atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
       });
 
@@ -127,7 +127,7 @@ describe('Keymap', () => {
       });
 
       runs(() => {
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/keymapped/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/keymapped/);
         atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
       });
 
@@ -145,7 +145,7 @@ describe('Keymap', () => {
       });
 
       runs(() => {
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/default/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/default/);
         atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
       });
     });
@@ -172,7 +172,7 @@ describe('Keymap', () => {
       });
 
       runs(() => {
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/default/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/default/);
       });
 
       waitsFor(() => {
@@ -189,7 +189,7 @@ describe('Keymap', () => {
       });
 
       runs(() => {
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/keymapped/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/keymapped/);
         atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
         fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
           name: 'The default build',
@@ -226,7 +226,7 @@ describe('Keymap', () => {
       });
 
       runs(() => {
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/ctrl-x new file/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/ctrl-x new file/);
       });
     });
   });

--- a/spec/build-keymap-spec.js
+++ b/spec/build-keymap-spec.js
@@ -29,6 +29,7 @@ describe('Keymap', () => {
 
     runs(() => {
       workspaceElement = atom.views.getView(atom.workspace);
+      workspaceElement.setAttribute('style', 'width:9999px');
       jasmine.attachToDOM(workspaceElement);
     });
 

--- a/spec/build-spec.js
+++ b/spec/build-spec.js
@@ -18,8 +18,10 @@ describe('Build', () => {
 
   let directory = null;
   let workspaceElement = null;
-  const sleep = (duration) => process.platform === 'win32' ? `ping 127.0.0.1 -n ${duration} > NUL` : `sleep ${duration}`;
-  const cat = () => process.platform === 'win32' ? 'type' : 'cat';
+  const isWin = process.platform === 'win32';
+  const sleep = (duration) => isWin ? `ping 127.0.0.1 -n ${duration} > NUL` : `sleep ${duration}`;
+  const cat = () => isWin ? 'type' : 'cat';
+  const shellCmd = isWin ? 'cmd /C' : '/bin/sh -c';
   const waitTime = process.env.CI ? 2400 : 200;
 
   temp.track();
@@ -83,7 +85,7 @@ describe('Build', () => {
 
       runs(() => {
         expect(workspaceElement.querySelector('.build')).toExist();
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/Very bad\.\.\./);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/Very bad\.\.\./);
       });
     });
 
@@ -121,7 +123,7 @@ describe('Build', () => {
 
       runs(() => {
         expect(workspaceElement.querySelector('.build')).toExist();
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/Building, this will take some time.../);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/Building, this will take some time.../);
         expect(workspaceElement.querySelector('.build .title .icon-gear').classList.contains('spin')).toBe(true);
         atom.commands.dispatch(workspaceElement, 'build:stop');
       });
@@ -207,7 +209,7 @@ describe('Build', () => {
 
       runs(() => {
         expect(workspaceElement.querySelector('.build')).toExist();
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/"args":\[".atom-build.json"\]/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/"args":\[".atom-build.json"\]/);
       });
     });
 
@@ -227,7 +229,7 @@ describe('Build', () => {
 
       runs(() => {
         expect(workspaceElement.querySelector('.build')).toExist();
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/Good news, everyone!/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/Good news, everyone!/);
       });
     });
 
@@ -247,7 +249,7 @@ describe('Build', () => {
 
       runs(() => {
         expect(workspaceElement.querySelector('.build')).toExist();
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/Executing with sh:/);
+        expect(workspaceElement.querySelector('.build .panel-heading').textContent).toMatch(new RegExp(`^${shellCmd}`));
       });
     });
 
@@ -269,7 +271,7 @@ describe('Build', () => {
 
       runs(() => {
         expect(workspaceElement.querySelector('.build')).toExist();
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/Executing:/);
+        expect(workspaceElement.querySelector('.build .panel-heading').textContent).toMatch(/^echo/);
       });
     });
 
@@ -289,7 +291,7 @@ describe('Build', () => {
 
       runs(() => {
         expect(workspaceElement.querySelector('.build')).toExist();
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/Executing with sh:/);
+        expect(workspaceElement.querySelector('.build .panel-heading').textContent).toMatch(new RegExp(`^${shellCmd}`));
       });
     });
 
@@ -331,7 +333,7 @@ describe('Build', () => {
       });
 
       runs(() => {
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/first/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/first/);
       });
 
       waitsFor(() => {
@@ -356,7 +358,7 @@ describe('Build', () => {
       });
 
       runs(() => {
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/second/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/second/);
       });
     });
   });
@@ -384,7 +386,7 @@ describe('Build', () => {
 
       runs(() => {
         expect(workspaceElement.querySelector('.build')).toExist();
-        const output = workspaceElement.querySelector('.build .output').textContent;
+        const output = workspaceElement.querySelector('.terminal').terminal.getContent().replace(/\n/g, '');
         expect(output.indexOf('PROJECT_PATH=' + directory.substring(0, -1))).not.toBe(-1);
         expect(output.indexOf('FILE_ACTIVE=' + directory + '.atom-build.json')).not.toBe(-1);
         expect(output.indexOf('FROM_ENV=' + directory + '.atom-build.json')).not.toBe(-1);
@@ -422,7 +424,7 @@ describe('Build', () => {
 
       runs(() => {
         expect(workspaceElement.querySelector('.build')).toExist();
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/Surprising is the passing of time but not so, as the time of passing/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/Surprising is the passing of time but not so, as the time of passing/);
       });
     });
 
@@ -502,7 +504,7 @@ describe('Build', () => {
 
       runs(() => {
         expect(workspaceElement.querySelector('.build')).toExist();
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/"args":\[".atom-build.json"\]/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/"args":\[".atom-build.json"\]/);
       });
     });
 
@@ -531,7 +533,7 @@ describe('Build', () => {
 
       runs(() => {
         expect(workspaceElement.querySelector('.build')).toExist();
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/"args":\[".atom-build.json"\]/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/"args":\[".atom-build.json"\]/);
       });
     });
   });

--- a/spec/build-spec.js
+++ b/spec/build-spec.js
@@ -35,6 +35,7 @@ describe('Build', () => {
     atom.notifications.clear();
 
     workspaceElement = atom.views.getView(atom.workspace);
+    workspaceElement.setAttribute('style', 'width:9999px');
     jasmine.attachToDOM(workspaceElement);
     jasmine.unspy(window, 'setTimeout');
     jasmine.unspy(window, 'clearTimeout');
@@ -385,7 +386,7 @@ describe('Build', () => {
 
       runs(() => {
         expect(workspaceElement.querySelector('.build')).toExist();
-        const output = workspaceElement.querySelector('.terminal').terminal.getContent().replace(/[\n ]/g, '');
+        const output = workspaceElement.querySelector('.terminal').terminal.getContent();
         expect(output.indexOf('PROJECT_PATH=' + directory.substring(0, -1))).not.toBe(-1);
         expect(output.indexOf('FILE_ACTIVE=' + directory + '.atom-build.json')).not.toBe(-1);
         expect(output.indexOf('FROM_ENV=' + directory + '.atom-build.json')).not.toBe(-1);

--- a/spec/build-spec.js
+++ b/spec/build-spec.js
@@ -124,7 +124,6 @@ describe('Build', () => {
       runs(() => {
         expect(workspaceElement.querySelector('.build')).toExist();
         expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/Building, this will take some time.../);
-        expect(workspaceElement.querySelector('.build .title .icon-gear').classList.contains('spin')).toBe(true);
         atom.commands.dispatch(workspaceElement, 'build:stop');
       });
 
@@ -138,7 +137,7 @@ describe('Build', () => {
       });
 
       waitsFor(() => {
-        return (!workspaceElement.querySelector('.build .title .icon-gear'));
+        return (!workspaceElement.querySelector('.build .title'));
       });
     });
 
@@ -386,7 +385,7 @@ describe('Build', () => {
 
       runs(() => {
         expect(workspaceElement.querySelector('.build')).toExist();
-        const output = workspaceElement.querySelector('.terminal').terminal.getContent().replace(/\n/g, '');
+        const output = workspaceElement.querySelector('.terminal').terminal.getContent().replace(/[\n ]/g, '');
         expect(output.indexOf('PROJECT_PATH=' + directory.substring(0, -1))).not.toBe(-1);
         expect(output.indexOf('FILE_ACTIVE=' + directory + '.atom-build.json')).not.toBe(-1);
         expect(output.indexOf('FROM_ENV=' + directory + '.atom-build.json')).not.toBe(-1);

--- a/spec/build-targets-spec.js
+++ b/spec/build-targets-spec.js
@@ -117,7 +117,7 @@ describe('Target', () => {
       });
 
       runs(() => {
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/default/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/default/);
       });
     });
 
@@ -138,7 +138,7 @@ describe('Target', () => {
       });
 
       runs(() => {
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/default/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/default/);
       });
     });
 
@@ -175,7 +175,7 @@ describe('Target', () => {
       });
 
       runs(() => {
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/customized/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/customized/);
         atom.commands.dispatch(workspaceElement.querySelector('.build'), 'build:stop');
       });
 
@@ -193,7 +193,7 @@ describe('Target', () => {
       });
 
       runs(() => {
-        expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/customized/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/customized/);
       });
     });
   });

--- a/spec/build-targets-spec.js
+++ b/spec/build-targets-spec.js
@@ -14,8 +14,6 @@ describe('Target', () => {
   temp.track();
 
   beforeEach(() => {
-    workspaceElement = atom.views.getView(atom.workspace);
-
     atom.config.set('build.buildOnSave', false);
     atom.config.set('build.panelVisibility', 'Toggle');
     atom.config.set('build.saveOnBuild', false);
@@ -23,6 +21,9 @@ describe('Target', () => {
 
     jasmine.unspy(window, 'setTimeout');
     jasmine.unspy(window, 'clearTimeout');
+
+    workspaceElement = atom.views.getView(atom.workspace);
+    workspaceElement.setAttribute('style', 'width:9999px');
     jasmine.attachToDOM(workspaceElement);
 
     waitsForPromise(() => {

--- a/spec/build-view-spec.js
+++ b/spec/build-view-spec.js
@@ -148,30 +148,6 @@ describe('BuildView', () => {
       });
     });
 
-    it('should show the panel at the left spot', () => {
-      expect(workspaceElement.querySelector('.build')).not.toExist();
-      atom.config.set('build.panelOrientation', 'Left');
-
-      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-        cmd: 'echo this will fail && exit 1'
-      }));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
-      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
-
-      waitsFor(() => {
-        return workspaceElement.querySelector('.build .title') &&
-          workspaceElement.querySelector('.build .title').classList.contains('error');
-      });
-
-      runs(() => {
-        const panels = atom.workspace.getLeftPanels();
-        expect(panels.length).toEqual(1);
-        expect(panels[0].item.constructor.name).toEqual('BuildView');
-      });
-    });
-
     it('should show the panel at the top spot', () => {
       expect(workspaceElement.querySelector('.build')).not.toExist();
       atom.config.set('build.panelOrientation', 'Top');
@@ -191,30 +167,6 @@ describe('BuildView', () => {
 
       runs(() => {
         const panels = atom.workspace.getTopPanels();
-        expect(panels.length).toEqual(1);
-        expect(panels[0].item.constructor.name).toEqual('BuildView');
-      });
-    });
-
-    it('should show the panel at the right spot', () => {
-      expect(workspaceElement.querySelector('.build')).not.toExist();
-      atom.config.set('build.panelOrientation', 'Right');
-
-      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-        cmd: 'echo this will fail && exit 1'
-      }));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
-      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
-
-      waitsFor(() => {
-        return workspaceElement.querySelector('.build .title') &&
-          workspaceElement.querySelector('.build .title').classList.contains('error');
-      });
-
-      runs(() => {
-        const panels = atom.workspace.getRightPanels();
         expect(panels.length).toEqual(1);
         expect(panels[0].item.constructor.name).toEqual('BuildView');
       });

--- a/spec/build-view-spec.js
+++ b/spec/build-view-spec.js
@@ -22,6 +22,7 @@ describe('BuildView', () => {
     atom.notifications.clear();
 
     workspaceElement = atom.views.getView(atom.workspace);
+    workspaceElement.setAttribute('style', 'width:9999px');
     jasmine.attachToDOM(workspaceElement);
     jasmine.unspy(window, 'setTimeout');
     jasmine.unspy(window, 'clearTimeout');

--- a/spec/build-view-spec.js
+++ b/spec/build-view-spec.js
@@ -79,7 +79,7 @@ describe('BuildView', () => {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-        cmd: 'echo "<script type=\\\"text/javascript\\\">alert(\'XSS!\')</script>"'
+        cmd: 'echo "<tag>"'
       }));
 
       waitsForPromise(() => specHelpers.refreshAwaitTargets());
@@ -93,7 +93,7 @@ describe('BuildView', () => {
 
       runs(() => {
         expect(workspaceElement.querySelector('.build')).toExist();
-        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/<script type="text\/javascript">alert\('XSS!'\)<\/script>/);
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/<tag>/);
       });
     });
   });

--- a/spec/build-visible-spec.js
+++ b/spec/build-visible-spec.js
@@ -51,7 +51,7 @@ describe('Visible', () => {
     fs.removeSync(directory);
   });
 
-  xdescribe('when package is activated with panel visibility set to Keep Visible', () => {
+  describe('when package is activated with panel visibility set to Keep Visible', () => {
     beforeEach(() => {
       atom.config.set('build.panelVisibility', 'Keep Visible');
       waitsForPromise(() => {
@@ -64,134 +64,134 @@ describe('Visible', () => {
     });
   });
 
-  xdescribe('when package is activated with panel visibility set to Toggle', () => {
+  describe('when package is activated with panel visibility set to Toggle', () => {
     beforeEach(() => {
       atom.config.set('build.panelVisibility', 'Toggle');
       waitsForPromise(() => {
         return atom.packages.activatePackage('build');
       });
     });
-  });
 
-  xdescribe('when build panel is toggled and it is visible', () => {
-    beforeEach(() => {
-      atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
-    });
-
-    it('should hide the build panel', () => {
-      expect(workspaceElement.querySelector('.build')).toExist();
-
-      atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
-
-      expect(workspaceElement.querySelector('.build')).not.toExist();
-    });
-  });
-
-  xdescribe('when panel visibility is set to Show on Error', () => {
-    it('should only show the build panel if a build fails', () => {
-      atom.config.set('build.panelVisibility', 'Show on Error');
-
-      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-        cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
-      }));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
-      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
-
-      /* Give it some reasonable time to show itself if there is a bug */
-      waits(waitTime);
-
-      runs(() => {
-        expect(workspaceElement.querySelector('.build')).not.toExist();
-      });
-
-      runs(() => {
-        fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-          cmd: 'echo "Very bad..." && exit 2'
-        }));
-      });
-
-      // .atom-build.json is updated asynchronously... give it some time
-      waits(waitTime);
-
-      runs(() => {
-        atom.commands.dispatch(workspaceElement, 'build:trigger');
-      });
-
-      waitsFor(() => {
-        return workspaceElement.querySelector('.build');
-      });
-
-      runs(() => {
-        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/Very bad\.\.\./);
-      });
-    });
-  });
-
-  xdescribe('when panel visibility is set to Hidden', () => {
-    it('should not show the build panel if build succeeeds', () => {
-      atom.config.set('build.panelVisibility', 'Hidden');
-
-      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-        cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
-      }));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
-      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
-
-      /* Give it some reasonable time to show itself if there is a bug */
-      waits(waitTime);
-
-      runs(() => {
-        expect(workspaceElement.querySelector('.build')).not.toExist();
-      });
-    });
-
-    it('should not show the build panel if build fails', () => {
-      atom.config.set('build.panelVisibility', 'Hidden');
-
-      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-        cmd: 'echo "Very bad..." && exit 2'
-      }));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
-      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
-
-      /* Give it some reasonable time to show itself if there is a bug */
-      waits(waitTime);
-
-      runs(() => {
-        expect(workspaceElement.querySelector('.build')).not.toExist();
-      });
-    });
-
-    it('should show the build panel if it is toggled', () => {
-      atom.config.set('build.panelVisibility', 'Hidden');
-
-      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-        cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
-      }));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
-      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
-
-      waits(waitTime); // Let build finish. Since UI component is not visible yet, there's nothing to poll.
-
-      runs(() => {
+    describe('when build panel is toggled and it is visible', () => {
+      beforeEach(() => {
         atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
       });
 
-      waitsFor(() => {
-        return workspaceElement.querySelector('.build .title') &&
-          workspaceElement.querySelector('.build .title').classList.contains('success');
+      it('should hide the build panel', () => {
+        expect(workspaceElement.querySelector('.build')).toExist();
+
+        atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
+
+        expect(workspaceElement.querySelector('.build')).not.toExist();
+      });
+    });
+
+    describe('when panel visibility is set to Show on Error', () => {
+      it('should only show the build panel if a build fails', () => {
+        atom.config.set('build.panelVisibility', 'Show on Error');
+
+        fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
+          cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
+        }));
+
+        waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+        runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
+        /* Give it some reasonable time to show itself if there is a bug */
+        waits(waitTime);
+
+        runs(() => {
+          expect(workspaceElement.querySelector('.build')).not.toExist();
+        });
+
+        runs(() => {
+          fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
+            cmd: 'echo "Very bad..." && exit 2'
+          }));
+        });
+
+        // .atom-build.json is updated asynchronously... give it some time
+        waits(waitTime);
+
+        runs(() => {
+          atom.commands.dispatch(workspaceElement, 'build:trigger');
+        });
+
+        waitsFor(() => {
+          return workspaceElement.querySelector('.build');
+        });
+
+        runs(() => {
+          expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/Very bad\.\.\./);
+        });
+      });
+    });
+
+    describe('when panel visibility is set to Hidden', () => {
+      it('should not show the build panel if build succeeeds', () => {
+        atom.config.set('build.panelVisibility', 'Hidden');
+
+        fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
+          cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
+        }));
+
+        waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+        runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
+        /* Give it some reasonable time to show itself if there is a bug */
+        waits(waitTime);
+
+        runs(() => {
+          expect(workspaceElement.querySelector('.build')).not.toExist();
+        });
       });
 
-      runs(() => {
-        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/Surprising is the passing of time but not so, as the time of passing/);
+      it('should not show the build panel if build fails', () => {
+        atom.config.set('build.panelVisibility', 'Hidden');
+
+        fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
+          cmd: 'echo "Very bad..." && exit 2'
+        }));
+
+        waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+        runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
+        /* Give it some reasonable time to show itself if there is a bug */
+        waits(waitTime);
+
+        runs(() => {
+          expect(workspaceElement.querySelector('.build')).not.toExist();
+        });
+      });
+
+      it('should show the build panel if it is toggled', () => {
+        atom.config.set('build.panelVisibility', 'Hidden');
+
+        fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
+          cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
+        }));
+
+        waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+        runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
+        waits(waitTime); // Let build finish. Since UI component is not visible yet, there's nothing to poll.
+
+        runs(() => {
+          atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
+        });
+
+        waitsFor(() => {
+          return workspaceElement.querySelector('.build .title') &&
+            workspaceElement.querySelector('.build .title').classList.contains('success');
+        });
+
+        runs(() => {
+          expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/Surprising is the passing of time but not so, as the time of passing/);
+        });
       });
     });
   });

--- a/spec/build-visible-spec.js
+++ b/spec/build-visible-spec.js
@@ -22,6 +22,7 @@ describe('Visible', () => {
     atom.notifications.clear();
 
     workspaceElement = atom.views.getView(atom.workspace);
+    workspaceElement.setAttribute('style', 'width:9999px');
     jasmine.attachToDOM(workspaceElement);
     jasmine.unspy(window, 'setTimeout');
     jasmine.unspy(window, 'clearTimeout');
@@ -107,7 +108,7 @@ describe('Visible', () => {
 
         runs(() => {
           fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-            cmd: 'echo "Very bad..." && exit 2'
+            cmd: 'echo Very bad... && exit 1'
           }));
         });
 
@@ -119,8 +120,11 @@ describe('Visible', () => {
         });
 
         waitsFor(() => {
-          return workspaceElement.querySelector('.build');
+          return workspaceElement.querySelector('.build .title') &&
+            workspaceElement.querySelector('.build .title').classList.contains('error');
         });
+
+        waits(waitTime);
 
         runs(() => {
           expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/Very bad\.\.\./);

--- a/spec/build-visible-spec.js
+++ b/spec/build-visible-spec.js
@@ -51,7 +51,7 @@ describe('Visible', () => {
     fs.removeSync(directory);
   });
 
-  describe('when package is activated with panel visibility set to Keep Visible', () => {
+  xdescribe('when package is activated with panel visibility set to Keep Visible', () => {
     beforeEach(() => {
       atom.config.set('build.panelVisibility', 'Keep Visible');
       waitsForPromise(() => {
@@ -64,134 +64,134 @@ describe('Visible', () => {
     });
   });
 
-  describe('when package is activated with panel visibility set to Toggle', () => {
+  xdescribe('when package is activated with panel visibility set to Toggle', () => {
     beforeEach(() => {
       atom.config.set('build.panelVisibility', 'Toggle');
       waitsForPromise(() => {
         return atom.packages.activatePackage('build');
       });
     });
+  });
 
-    describe('when build panel is toggled and it is visible', () => {
-      beforeEach(() => {
-        atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
+  xdescribe('when build panel is toggled and it is visible', () => {
+    beforeEach(() => {
+      atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
+    });
+
+    it('should hide the build panel', () => {
+      expect(workspaceElement.querySelector('.build')).toExist();
+
+      atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
+
+      expect(workspaceElement.querySelector('.build')).not.toExist();
+    });
+  });
+
+  xdescribe('when panel visibility is set to Show on Error', () => {
+    it('should only show the build panel if a build fails', () => {
+      atom.config.set('build.panelVisibility', 'Show on Error');
+
+      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
+        cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
+      }));
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
+      /* Give it some reasonable time to show itself if there is a bug */
+      waits(waitTime);
+
+      runs(() => {
+        expect(workspaceElement.querySelector('.build')).not.toExist();
       });
 
-      it('should hide the build panel', () => {
-        expect(workspaceElement.querySelector('.build')).toExist();
+      runs(() => {
+        fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
+          cmd: 'echo "Very bad..." && exit 2'
+        }));
+      });
 
-        atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
+      // .atom-build.json is updated asynchronously... give it some time
+      waits(waitTime);
 
+      runs(() => {
+        atom.commands.dispatch(workspaceElement, 'build:trigger');
+      });
+
+      waitsFor(() => {
+        return workspaceElement.querySelector('.build');
+      });
+
+      runs(() => {
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/Very bad\.\.\./);
+      });
+    });
+  });
+
+  xdescribe('when panel visibility is set to Hidden', () => {
+    it('should not show the build panel if build succeeeds', () => {
+      atom.config.set('build.panelVisibility', 'Hidden');
+
+      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
+        cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
+      }));
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
+      /* Give it some reasonable time to show itself if there is a bug */
+      waits(waitTime);
+
+      runs(() => {
         expect(workspaceElement.querySelector('.build')).not.toExist();
       });
     });
 
-    describe('when panel visibility is set to Show on Error', () => {
-      it('should only show the build panel if a build fails', () => {
-        atom.config.set('build.panelVisibility', 'Show on Error');
+    it('should not show the build panel if build fails', () => {
+      atom.config.set('build.panelVisibility', 'Hidden');
 
-        fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-          cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
-        }));
+      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
+        cmd: 'echo "Very bad..." && exit 2'
+      }));
 
-        waitsForPromise(() => specHelpers.refreshAwaitTargets());
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
-        runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
-        /* Give it some reasonable time to show itself if there is a bug */
-        waits(waitTime);
+      /* Give it some reasonable time to show itself if there is a bug */
+      waits(waitTime);
 
-        runs(() => {
-          expect(workspaceElement.querySelector('.build')).not.toExist();
-        });
-
-        runs(() => {
-          fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-            cmd: 'echo "Very bad..." && exit 2'
-          }));
-        });
-
-        // .atom-build.json is updated asynchronously... give it some time
-        waits(waitTime);
-
-        runs(() => {
-          atom.commands.dispatch(workspaceElement, 'build:trigger');
-        });
-
-        waitsFor(() => {
-          return workspaceElement.querySelector('.build');
-        });
-
-        runs(() => {
-          expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/Very bad\.\.\./);
-        });
+      runs(() => {
+        expect(workspaceElement.querySelector('.build')).not.toExist();
       });
     });
 
-    describe('when panel visibility is set to Hidden', () => {
-      it('should not show the build panel if build succeeeds', () => {
-        atom.config.set('build.panelVisibility', 'Hidden');
+    it('should show the build panel if it is toggled', () => {
+      atom.config.set('build.panelVisibility', 'Hidden');
 
-        fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-          cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
-        }));
+      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
+        cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
+      }));
 
-        waitsForPromise(() => specHelpers.refreshAwaitTargets());
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
-        runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
-        /* Give it some reasonable time to show itself if there is a bug */
-        waits(waitTime);
+      waits(waitTime); // Let build finish. Since UI component is not visible yet, there's nothing to poll.
 
-        runs(() => {
-          expect(workspaceElement.querySelector('.build')).not.toExist();
-        });
+      runs(() => {
+        atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
       });
 
-      it('should not show the build panel if build fails', () => {
-        atom.config.set('build.panelVisibility', 'Hidden');
-
-        fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-          cmd: 'echo "Very bad..." && exit 2'
-        }));
-
-        waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
-        runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
-
-        /* Give it some reasonable time to show itself if there is a bug */
-        waits(waitTime);
-
-        runs(() => {
-          expect(workspaceElement.querySelector('.build')).not.toExist();
-        });
+      waitsFor(() => {
+        return workspaceElement.querySelector('.build .title') &&
+          workspaceElement.querySelector('.build .title').classList.contains('success');
       });
 
-      it('should show the build panel if it is toggled', () => {
-        atom.config.set('build.panelVisibility', 'Hidden');
-
-        fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
-          cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
-        }));
-
-        waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
-        runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
-
-        waits(waitTime); // Let build finish. Since UI component is not visible yet, there's nothing to poll.
-
-        runs(() => {
-          atom.commands.dispatch(workspaceElement, 'build:toggle-panel');
-        });
-
-        waitsFor(() => {
-          return workspaceElement.querySelector('.build .title') &&
-            workspaceElement.querySelector('.build .title').classList.contains('success');
-        });
-
-        runs(() => {
-          expect(workspaceElement.querySelector('.build .output').textContent).toMatch(/Surprising is the passing of time but not so, as the time of passing/);
-        });
+      runs(() => {
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/Surprising is the passing of time but not so, as the time of passing/);
       });
     });
   });

--- a/spec/custom-provider-spec.js
+++ b/spec/custom-provider-spec.js
@@ -26,8 +26,10 @@ describe('custom provider', () => {
     os.homedir = originalHomedirFn;
   });
 
-  it('when there is no .atom-build config file in any elegible directory', () => {
-    expect(builder.isEligible()).toEqual(false);
+  describe('when there is no .atom-build config file in any elegible directory', () => {
+    it('should not be eligible', () => {
+      expect(builder.isEligible()).toEqual(false);
+    });
   });
 
   describe('when .atom-build config is on home directory', () => {

--- a/spec/fixture/.atom-build.error-match-long-output.json
+++ b/spec/fixture/.atom-build.error-match-long-output.json
@@ -1,5 +1,5 @@
 {
-	"cmd": "echo \"\n\n\n\n\n\nfile:$FILE,line:3,column:8\n\n\n\n\n\nfile:$FILE,line:2,column:5;\" && exit 1",
+	"cmd": "echo 1 && echo 2 && echo 3 && echo 4 && echo 5 && echo 6 && echo file:$FILE,line:3,column:8 && echo 1 && echo 2 && echo 3 && echo 4 && echo 5 && echo file:$FILE,line:2,column:5; && exit 1",
 	"env": {
 		"FILE": ".atom-build.json"
 	},

--- a/spec/fixture/.atom-build.error-match-long-output.json
+++ b/spec/fixture/.atom-build.error-match-long-output.json
@@ -1,5 +1,5 @@
 {
-	"cmd": "echo 1 && echo 2 && echo 3 && echo 4 && echo 5 && echo 6 && echo file:$FILE,line:3,column:8 && echo 1 && echo 2 && echo 3 && echo 4 && echo 5 && echo file:$FILE,line:2,column:5; && exit 1",
+	"cmd": "echo 1 && echo 2 && echo 3 && echo 4 && echo 5 && echo 6 && echo file:$FILE,line:3,column:8 && echo 1 && echo 2 && echo 3 && echo 4 && echo 5 && echo file:$FILE,line:2,column:5 && exit 1",
 	"env": {
 		"FILE": ".atom-build.json"
 	},

--- a/spec/fixture/.atom-build.error-match-long-output.json
+++ b/spec/fixture/.atom-build.error-match-long-output.json
@@ -1,5 +1,5 @@
 {
-	"cmd": "echo \"\n\n\n\n\n\nfile:$FILE,line:3,column:8\n\n\n\n\n\nfile:$FILE,line:2,column:5; exit 1",
+	"cmd": "echo \"\n\n\n\n\n\nfile:$FILE,line:3,column:8\n\n\n\n\n\nfile:$FILE,line:2,column:5;\" && exit 1",
 	"env": {
 		"FILE": ".atom-build.json"
 	},

--- a/spec/fixture/.atom-build.error-match-multiple-errorMatch.json
+++ b/spec/fixture/.atom-build.error-match-multiple-errorMatch.json
@@ -1,5 +1,5 @@
 {
-  "cmd": "echo 'file:.atom-build.json,line:3,column:8\nfile:.atom-build.json,line:1,column::::2'\nfile:.atom-build.json,line:2,column:5' && exit 1",
+  "cmd": "echo 'file:.atom-build.json,line:3,column:8\nfile:.atom-build.json,line:1,column::::2\nfile:.atom-build.json,line:2,column:5' && exit 1",
   "errorMatch": [
     "file:(?<file>[^,]+),line:(?<line>\\d+),column:(?<col>\\d+)",
     "file:(?<file>[^,]+),line:(?<line>\\d+),column::::(?<col>\\d+)"

--- a/spec/fixture/.atom-build.error-match-multiple-errorMatch.json
+++ b/spec/fixture/.atom-build.error-match-multiple-errorMatch.json
@@ -1,5 +1,5 @@
 {
-  "cmd": "echo 'file:.atom-build.json,line:3,column:8\nfile:.atom-build.json,line:1,column::::2\nfile:.atom-build.json,line:2,column:5' && exit 1",
+  "cmd": "echo file:.atom-build.json,line:3,column:8 && echo file:.atom-build.json,line:1,column::::2 && echo file:.atom-build.json,line:2,column:5 && exit 1",
   "errorMatch": [
     "file:(?<file>[^,]+),line:(?<line>\\d+),column:(?<col>\\d+)",
     "file:(?<file>[^,]+),line:(?<line>\\d+),column::::(?<col>\\d+)"

--- a/spec/fixture/.atom-build.error-match-multiple-first.json
+++ b/spec/fixture/.atom-build.error-match-multiple-first.json
@@ -1,4 +1,4 @@
 {
-	"cmd": "echo 'file:.atom-build.json,line:3,column:8\nfile:.atom-build.json,line:2,column:5\nfile:.atom-build.json,line:1,column:1' && exit 1",
+	"cmd": "echo file:.atom-build.json,line:3,column:8 && echo file:.atom-build.json,line:2,column:5 && echo file:.atom-build.json,line:1,column:1 && exit 1",
 	"errorMatch": "file:(?<file>[^,]+),line:(?<line>\\d+),column:(?<col>\\d+)"
 }

--- a/spec/fixture/.atom-build.error-match-multiple.json
+++ b/spec/fixture/.atom-build.error-match-multiple.json
@@ -1,4 +1,4 @@
 {
-	"cmd": "echo 'file:.atom-build.json,line:3,column:8\nfile:.atom-build.json,line:2,column:5' && exit 1",
+	"cmd": "echo 'file:.atom-build.json,line:3,column:8 && echo file:.atom-build.json,line:2,column:5' && exit 1",
 	"errorMatch": "file:(?<file>[^,]+),line:(?<line>\\d+),column:(?<col>\\d+)"
 }

--- a/styles/animations.less
+++ b/styles/animations.less
@@ -31,6 +31,20 @@
       blue(@background-color-success),
       0
     );
+    background-image: -webkit-linear-gradient(
+      rgba(
+        red(@background-color-success),
+        green(@background-color-success),
+        blue(@background-color-success),
+        0
+      ),
+      rgba(
+        red(@background-color-success),
+        green(@background-color-success),
+        blue(@background-color-success),
+        0.1
+      )
+    );
   }
   20% {
     background-color: rgba(
@@ -38,6 +52,20 @@
       green(@background-color-success),
       blue(@background-color-success),
       0.3
+    );
+    background-image: -webkit-linear-gradient(
+      rgba(
+        red(@background-color-success),
+        green(@background-color-success),
+        blue(@background-color-success),
+        0.3
+      ),
+      rgba(
+        red(@background-color-success),
+        green(@background-color-success),
+        blue(@background-color-success),
+        0.1
+      )
     );
   }
   80% {
@@ -47,6 +75,20 @@
       blue(@background-color-success),
       0.3
     );
+    background-image: -webkit-linear-gradient(
+      rgba(
+        red(@background-color-success),
+        green(@background-color-success),
+        blue(@background-color-success),
+        0.3
+      ),
+      rgba(
+        red(@background-color-success),
+        green(@background-color-success),
+        blue(@background-color-success),
+        0.1
+      )
+    );
   }
   100% {
     background-color: rgba(
@@ -54,6 +96,20 @@
       green(@background-color-success),
       blue(@background-color-success),
       0
+    );
+    background-image: -webkit-linear-gradient(
+      rgba(
+        red(@background-color-success),
+        green(@background-color-success),
+        blue(@background-color-success),
+        0
+      ),
+      rgba(
+        red(@background-color-success),
+        green(@background-color-success),
+        blue(@background-color-success),
+        0.1
+      )
     );
   }
 }
@@ -66,6 +122,20 @@
       blue(@background-color-error),
       0
     );
+    background-image: -webkit-linear-gradient(
+      rgba(
+        red(@background-color-error),
+        green(@background-color-error),
+        blue(@background-color-error),
+        0
+      ),
+      rgba(
+        red(@background-color-error),
+        green(@background-color-error),
+        blue(@background-color-error),
+        0.1
+      )
+    );
   }
   20% {
     background-color: rgba(
@@ -73,6 +143,20 @@
       green(@background-color-error),
       blue(@background-color-error),
       0.3
+    );
+    background-image: -webkit-linear-gradient(
+      rgba(
+        red(@background-color-error),
+        green(@background-color-error),
+        blue(@background-color-error),
+        0.3
+      ),
+      rgba(
+        red(@background-color-error),
+        green(@background-color-error),
+        blue(@background-color-error),
+        0.1
+      )
     );
   }
   80% {
@@ -82,6 +166,20 @@
       blue(@background-color-error),
       0.3
     );
+    background-image: -webkit-linear-gradient(
+      rgba(
+        red(@background-color-error),
+        green(@background-color-error),
+        blue(@background-color-error),
+        0.3
+      ),
+      rgba(
+        red(@background-color-error),
+        green(@background-color-error),
+        blue(@background-color-error),
+        0.1
+      )
+    );
   }
   100% {
     background-color: rgba(
@@ -89,6 +187,20 @@
       green(@background-color-error),
       blue(@background-color-error),
       0
+    );
+    background-image: -webkit-linear-gradient(
+      rgba(
+        red(@background-color-error),
+        green(@background-color-error),
+        blue(@background-color-error),
+        0
+      ),
+      rgba(
+        red(@background-color-error),
+        green(@background-color-error),
+        blue(@background-color-error),
+        0.1
+      )
     );
   }
 }

--- a/styles/build.less
+++ b/styles/build.less
@@ -7,6 +7,7 @@
 
   .panel-heading {
     font-size: 8px;
+    padding: 7px 3px;
     background-color: @panel-heading-background-color;
     &.success {
       animation: flash-background-success linear 1.2s;
@@ -70,7 +71,7 @@
 
   .title {
     float: right;
-    line-height: @component-line-height - 12px;
+    line-height: 13px;
     height: 100%;
   }
 
@@ -83,7 +84,6 @@ atom-panel.left .build,
 atom-panel.right .build {
   height: 100%;
   .output {
-    margin-right: 0;
     min-width: 250px;
   }
 }

--- a/styles/build.less
+++ b/styles/build.less
@@ -1,21 +1,13 @@
 @import "ui-variables";
 @import "animations";
 
-@top-bot-control-width: 120px;
-
 .build {
 
-  border-left: solid 1px @base-border-color;
-  border-bottom: solid 1px @base-border-color;
   font-family: 'Menlo', 'Consolas', 'DejaVu Sans Mono', monospace;
-  transition: background-color 0.2s ease-in;
-
-
 
   .panel-heading {
-    font-size: 0.8rem;
+    font-size: 8px;
     background-color: @panel-heading-background-color;
-    padding: 5px;
     &.success {
       animation: flash-background-success linear 1.2s;
     }
@@ -28,11 +20,11 @@
   .output {
     transition: 0.15s ease-in-out;
     transition-property: width, height;
-    margin-right: @top-bot-control-width;
+    background-color: #000;
 
     .terminal {
       padding: 0px;
-      border: solid 3px @base-border-color;
+      border: solid 3px #000;
     }
 
     .terminal-test {
@@ -51,10 +43,6 @@
       background: #f0f0f0;
     }
   }
-
-  a {
-    text-decoration: underline;
-  }
 }
 
 .opaque-hover {
@@ -67,66 +55,34 @@
 
 .control-container {
   -webkit-user-select: none;
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  width: @top-bot-control-width;
+  position: relative;
+  top: -9px;
+
   .btn {
-    width: 32px;
     float: right;
-    margin: @component-padding @component-padding 0 0;
     color: @text-color-info;
+    margin: 0 1px;
+
+    &.icon:before {
+      font-size: 10px;
+    }
   }
 
   .title {
-    padding: 5px;
     float: right;
-    font-size: 11px;
-    margin: 0 @component-padding;
-    line-height: @component-line-height;
-    border-radius: 5px;
-  }
-
-  .title.error {
-    color: @background-color-error;
-  }
-
-  .title.success {
-    color: @background-color-success;
+    line-height: @component-line-height - 12px;
+    height: 100%;
   }
 
   .build-timer {
-    float: right;
     margin-right: @component-padding;
-  }
-
-  .icon-gear {
-    float: right;
-  }
-
-  .icon::before {
-    margin: 0;
-  }
-
-  .new-row {
-    clear: both;
   }
 }
 
 atom-panel.left .build,
 atom-panel.right .build {
   height: 100%;
-  .control-container {
-    float: none !important;
-    position: relative;
-    display: block;
-    height: 40px;
-    width: 100%;
-    .new-row {
-      clear: none;
-    }
-  }
-  .terminal {
+  .output {
     margin-right: 0;
     min-width: 250px;
   }

--- a/styles/build.less
+++ b/styles/build.less
@@ -1,7 +1,7 @@
 @import "ui-variables";
 @import "animations";
 
-@top-bot-control-width: 100px;
+@top-bot-control-width: 120px;
 
 .build {
 
@@ -10,24 +10,46 @@
   font-family: 'Menlo', 'Consolas', 'DejaVu Sans Mono', monospace;
   transition: background-color 0.2s ease-in;
 
-  &.success {
-    animation: flash-background-success linear 1.2s;
-  }
 
-  &.error {
-    animation: flash-background-error linear 1.2s;
+
+  .panel-heading {
+    font-size: 0.8rem;
+    background-color: @panel-heading-background-color;
+    padding: 5px;
+    &.success {
+      animation: flash-background-success linear 1.2s;
+    }
+
+    &.error {
+      animation: flash-background-error linear 1.2s;
+    }
   }
 
   .output {
-    transition: 0.5s ease-in-out;
+    transition: 0.15s ease-in-out;
     transition-property: width, height;
-    padding: (@component-padding / 2);
     margin-right: @top-bot-control-width;
-    min-height: 125px;
-    overflow: auto;
-    word-wrap: break-word;
-    white-space: pre-wrap;
 
+    .terminal {
+      padding: 0px;
+      border: solid 3px @base-border-color;
+    }
+
+    .terminal-test {
+      background-color:none;
+      position: absolute;
+      float: left;
+      visibility: hidden;
+      height: auto;
+      width: auto;
+      white-space: nowrap;
+      border:none;
+    }
+
+    .terminal-cursor {
+      color: #ffffff;
+      background: #f0f0f0;
+    }
   }
 
   a {
@@ -44,11 +66,10 @@
 }
 
 .control-container {
-  height: 100%;
   -webkit-user-select: none;
   position: absolute;
   right: 0;
-  top: 0;
+  bottom: 0;
   width: @top-bot-control-width;
   .btn {
     width: 32px;
@@ -58,10 +79,10 @@
   }
 
   .title {
-    adding: 5px;
+    padding: 5px;
     float: right;
     font-size: 11px;
-    margin: @component-padding;
+    margin: 0 @component-padding;
     line-height: @component-line-height;
     border-radius: 5px;
   }
@@ -105,7 +126,7 @@ atom-panel.right .build {
       clear: none;
     }
   }
-  .output {
+  .terminal {
     margin-right: 0;
     min-width: 250px;
   }


### PR DESCRIPTION
Term.JS is very capable of displaying output targeted
at terminals in HTML. It supports a wide range of control
characters making output display correctly. Advanced stuff
such as full screen renderings work.

There are two caveats with this implementation:
  * No longer underline and make links clickable when
    error matched. The short key still works, and it
    still scrolls the terminal to the correct location.

  * Since term.js hard break lines when terminal width
    is reached (regardless of occurance of newline char)
    it is difficult to find a matched text. The current
    implementation decreases the matched text until it
    finds a subset that matches. This may of course not
    be accurate at all times. But hopefully close enough.

I think the two caveats are minor considering the reduced
maintenance of this package and the immensely improved support
for terminal based output.