### PR TITLE
Only re-focus if we still "own" focus

### DIFF
--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -130,7 +130,7 @@ export default class BuildView extends View {
 
   detach(force) {
     force = force || false;
-    if (atom.views.getView(atom.workspace)) {
+    if (atom.views.getView(atom.workspace) && document.activeElement === this[0]) {
       atom.views.getView(atom.workspace).focus();
     }
     if (this.panel && (force || 'Keep Visible' !== atom.config.get('build.panelVisibility'))) {


### PR DESCRIPTION
When a build has completed, only reset the focus
if we still "own" the focus, i.e. no other focus
choices has been made by the user.

Fixes #300