### PR TITLE
Handle if project folder has gone away

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -117,8 +117,13 @@ export default {
 
     /* otherwise, build the one in the root of the active editor */
     return atom.project.getPaths().sort((a, b) => (b.length - a.length)).find(p => {
-      const realpath = fs.realpathSync(p);
-      return textEditor.getPath().substr(0, realpath.length) === realpath;
+      try {
+        const realpath = fs.realpathSync(p);
+        return textEditor.getPath().substr(0, realpath.length) === realpath;
+      } catch (err) {
+        /* Path no longer available. Possible network volume has gone down */
+        return false;
+      }
     });
   },
 


### PR DESCRIPTION
If the project folder for some reason can not
be derive `realpath`, skip that folder and continue
with other potential candidates.

Fixes #273
Fixes #322