### PR TITLE
Removed lodash dependency

### DIFF
--- a/lib/atom-build.js
+++ b/lib/atom-build.js
@@ -2,7 +2,6 @@
 
 import path from 'path';
 import fs from 'fs';
-import _ from 'lodash';
 import CSON from 'cson-parser';
 import yaml from 'js-yaml';
 import EventEmitter from 'events';
@@ -72,7 +71,7 @@ export default class CustomFile extends EventEmitter {
     this.files.map(getConfig).forEach(build => {
       config.push(
         createBuildConfig(build, build.name || 'default'),
-        ..._.map(build.targets, (target, name) => createBuildConfig(target, name))
+        ...Object.keys(build.targets || {}).map(name => createBuildConfig(build.targets[name], name))
       );
     });
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -2,7 +2,6 @@
 
 import fs from 'fs';
 import path from 'path';
-import _ from 'lodash';
 import { Disposable, CompositeDisposable } from 'atom';
 import kill from 'tree-kill';
 import Grim from 'grim';
@@ -87,7 +86,7 @@ export default {
   },
 
   deactivate() {
-    _.map(this.instancedTools, (tools, cwd) => tools.forEach(tool => {
+    Object.keys(this.instancedTools).map(cwd => this.instancedTools[cwd].forEach(tool => {
       tool.removeAllListeners && tool.removeAllListeners('refresh');
       tool.destructor && tool.destructor();
     }));
@@ -132,31 +131,49 @@ export default {
     this.statusBarView && this.statusBarView.setTarget(activeTarget);
   },
 
-  cmdDefaults(cwd) {
-    return {
-      env: {},
-      args: [],
-      cwd: cwd,
-      sh: true,
-      errorMatch: ''
-    };
+  getDefaults(cwd, setting) {
+    return Object.assign({}, setting, {
+      env: setting.env || {},
+      args: setting.args || [],
+      cwd: setting.cwd || cwd,
+      sh: (undefined === setting.sh) ? true : setting.sh,
+      errorMatch: setting.errorMatch || ''
+    });
   },
 
   settingsMakeUnique(settings) {
-    let diff;
+    let rest;
+    let tmpFilter;
+
     const appender = (setting) => {
       setting._uniqueIndex = setting._uniqueIndex || 1;
       setting._originalName = setting._originalName || setting.name;
       setting.name = `${setting._originalName} - ${setting._uniqueIndex++}`;
       settings.push(setting);
     };
+
+    const uniqfilter = (setting) => {
+      if (-1 === tmpFilter.indexOf(setting.name)) {
+        tmpFilter.push(setting.name);
+        return true;
+      }
+      tmpFilter.push(setting.name);
+      rest.push(setting);
+    };
+
     let i = 0;
     do {
-      const uniqueSettings = _.uniq(settings, 'name');
-      diff = _.difference(settings, uniqueSettings);
+      rest = [];
+      tmpFilter = [];
+      const uniqueSettings = settings.filter(uniqfilter);
+
+      if (rest.length === 0) {
+        break;
+      }
+
       settings = uniqueSettings;
-      diff.forEach(appender);
-    } while (diff.length > 0 && i++ < 10);
+      rest.forEach(appender);
+    } while (rest.length > 0 && i++ < 10);
 
     return settings;
   },
@@ -196,11 +213,11 @@ export default {
         });
 
       return Promise.all(settingsPromise).then((settings) => {
-        settings = this.settingsMakeUnique([].concat.apply([], settings).filter(Boolean).map(setting =>
-          _.defaults(setting, this.cmdDefaults(p))
-        ));
+        settings = this.settingsMakeUnique([].concat.apply([], settings)
+          .filter(Boolean)
+          .map(setting => this.getDefaults(p, setting)));
 
-        if (_.isNull(this.activeTarget[p]) || !settings.find(s => s.name === this.activeTarget[p])) {
+        if (null === this.activeTarget[p] || !settings.find(s => s.name === this.activeTarget[p])) {
           /* Active target has been removed or not set. Set it to the highest prio target */
           this.activeTarget[p] = settings[0] ? settings[0].name : undefined;
         }
@@ -282,14 +299,14 @@ export default {
   },
 
   replace(value = '', targetEnv) {
-    const env = _.extend({}, process.env, targetEnv);
+    const env = Object.assign({}, process.env, targetEnv);
     value = value.replace(/\$(\w+)/g, function (match, name) {
       return name in env ? env[name] : match;
     });
 
     const editor = atom.workspace.getActiveTextEditor();
 
-    const projectPaths = _.map(atom.project.getPaths(), (projectPath) => {
+    const projectPaths = atom.project.getPaths().map(projectPath => {
       try {
         return fs.realpathSync(projectPath);
       } catch (e) { /* Do nothing. */ }
@@ -299,7 +316,7 @@ export default {
     if (editor && (undefined !== editor.getPath())) {
       const activeFile = fs.realpathSync(editor.getPath());
       const activeFilePath = path.dirname(activeFile);
-      projectPath = _.find(projectPaths, (p) => activeFilePath && activeFilePath.startsWith(p));
+      projectPath = projectPaths.find(p => activeFilePath && activeFilePath.startsWith(p));
       value = value.replace(/{FILE_ACTIVE}/g, activeFile);
       value = value.replace(/{FILE_ACTIVE_PATH}/g, activeFilePath);
       value = value.replace(/{FILE_ACTIVE_NAME}/g, path.basename(activeFile));
@@ -338,9 +355,9 @@ export default {
         }
       }).then(() => target);
     }).then(target => {
-      const env = _.extend({}, process.env, target.env);
-      _.forEach(env, (value, key, list) => {
-        list[key] = this.replace(value, target.env);
+      const env = Object.assign({}, process.env, target.env);
+      Object.keys(env).forEach(key => {
+        env[key] = this.replace(env[key], target.env);
       });
 
       const exec = this.replace(target.exec, target.env);
@@ -468,7 +485,7 @@ export default {
       continuecb();
     };
 
-    if (0 === _.size(modifiedTextEditors) || atom.config.get('build.saveOnBuild')) {
+    if (0 === modifiedTextEditors.length || atom.config.get('build.saveOnBuild')) {
       return saveAndContinue(true);
     }
 
@@ -505,10 +522,11 @@ export default {
     return this.consumeBuilder(providerLegacy(builder));
   },
 
-  consumeBuilder(builders) {
-    builders = Array.isArray(builders) ? builders : [ builders ];
-    this.tools = _.union(this.tools, builders);
-    return new Disposable(() => this.tools = _.difference(this.tools, builders));
+  consumeBuilder(builder) {
+    this.tools.push(builder);
+    return new Disposable(() => {
+      this.tools = this.tools.filter(tool => tool !== builder);
+    });
   },
 
   consumeStatusBar(statusBar) {

--- a/lib/google-analytics.js
+++ b/lib/google-analytics.js
@@ -1,6 +1,5 @@
 'use babel';
 
-import _ from 'lodash';
 import querystring from 'querystring';
 
 export default class GoogleAnalytics {
@@ -39,7 +38,7 @@ export default class GoogleAnalytics {
     }
 
     GoogleAnalytics.getCid((cid) => {
-      _.extend(params, { cid: cid }, GoogleAnalytics.defaultParams());
+      Object.assign(params, { cid: cid }, GoogleAnalytics.defaultParams());
       this.request('https://www.google-analytics.com/collect?' + querystring.stringify(params));
     });
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "getmac": "^1.0.7",
     "grim": "^2.0.0",
     "js-yaml": "^3.4.6",
-    "lodash": "^3.8.0",
     "node-uuid": "^1.4.3",
     "term.js": "git+https://github.com/jeremyramin/term.js.git#de1635fc2695e7d8165012d3b1d007d7ce60eea2",
     "tree-kill": "^1.0.0",

--- a/spec/build-confirm-spec.js
+++ b/spec/build-confirm-spec.js
@@ -1,6 +1,5 @@
 'use babel';
 
-import _ from 'lodash';
 import fs from 'fs-extra';
 import temp from 'temp';
 import specHelpers from 'atom-build-spec-helpers';
@@ -120,7 +119,7 @@ describe('Confirm', () => {
       });
 
       runs(() => {
-        const editor = _.find(atom.workspace.getTextEditors(), (textEditor) => {
+        const editor = atom.workspace.getTextEditors().find(textEditor => {
           return ('untitled' === textEditor.getTitle());
         });
         editor.insertText('Just some temporary place to write stuff');

--- a/spec/build-targets-spec.js
+++ b/spec/build-targets-spec.js
@@ -1,6 +1,5 @@
 'use babel';
 
-import _ from 'lodash';
 import fs from 'fs-extra';
 import temp from 'temp';
 import specHelpers from 'atom-build-spec-helpers';
@@ -66,7 +65,7 @@ describe('Target', () => {
       });
 
       runs(() => {
-        const targets = _.map(workspaceElement.querySelectorAll('.select-list li.build-target'), el => el.textContent);
+        const targets = [ ...workspaceElement.querySelectorAll('.select-list li.build-target') ].map(el => el.textContent);
         expect(targets).toEqual([ 'Custom: The default build', 'Custom: Some customized build' ]);
       });
     });


### PR DESCRIPTION
With the entry of ES6, and the possibility to use
babel to transpile both ES6 and ES7 to ES5 compatible
javascript, there really is no need for utility library lodash.
Removing it speeds up load times for build.