### PR TITLE
Optionally override theme with terminal style

### DIFF
--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -62,6 +62,10 @@ export default class BuildView extends View {
 
     atom.config.observe('build.panelVisibility', ::this.visibleFromConfig);
     atom.config.observe('build.panelOrientation', ::this.orientationFromConfig);
+    atom.config.observe('build.overrideThemeColors', (override) => {
+      this.output.removeClass('override-theme');
+      override && this.output.addClass('override-theme');
+    });
     atom.config.observe('editor.fontSize', ::this.fontSizeFromConfig);
     atom.config.observe('editor.fontFamily', ::this.fontFamilyFromConfig);
     atom.commands.add('atom-workspace', 'build:toggle-panel', ::this.toggle);

--- a/lib/config.js
+++ b/lib/config.js
@@ -44,26 +44,33 @@ export default {
     default: true,
     order: 6
   },
+  overrideThemeColors: {
+    title: 'Override Theme Colors',
+    description: 'Override theme background- and text color inside the terminal',
+    type: 'boolean',
+    default: true,
+    order: 7
+  },
   selectTriggers: {
     title: 'Selecting new target triggers the build',
     description: 'When selecting a new target (through status-bar, cmd-alt-t, etc), the newly selected target will be triggered.',
     type: 'boolean',
     default: true,
-    order: 7
+    order: 8
   },
   notificationOnRefresh: {
     title: 'Show notification when targets are refreshed',
     description: 'When targets are refreshed a notification with information about the number of targets will be displayed.',
     type: 'boolean',
     default: false,
-    order: 8
+    order: 9
   },
   beepWhenDone: {
     title: 'Beep when the build completes',
     description: 'Make a "beep" notification sound when the build is complete - in success or failure.',
     type: 'boolean',
     default: false,
-    order: 9
+    order: 10
   },
   panelOrientation: {
     title: 'Panel Orientation',
@@ -71,7 +78,7 @@ export default {
     type: 'string',
     default: 'Bottom',
     enum: [ 'Bottom', 'Top', 'Left', 'Right' ],
-    order: 12
+    order: 11
   },
   statusBar: {
     title: 'Status Bar',
@@ -79,13 +86,13 @@ export default {
     type: 'string',
     default: 'Left',
     enum: [ 'Left', 'Right', 'Disable' ],
-    order: 13
+    order: 12
   },
   statusBarPriority: {
     title: 'Priority on Status Bar',
     description: 'Lower priority tiles are placed further to the left/right, depends on where you choose to place Status Bar.',
     type: 'number',
     default: -1000,
-    order: 14
+    order: 13
   }
 };

--- a/styles/build.less
+++ b/styles/build.less
@@ -68,7 +68,10 @@
   }
 
   .output {
-    background-color: #000;
+    &.override-theme {
+      color: #fff;
+      background-color: #000;
+    }
 
     .terminal {
       padding: 0;


### PR DESCRIPTION
Terminal works "best" under black background and white
text. However this may not look very good with light theme,
or other dark themes. Allow user to opt out of overriden
colors.

Fixes #338