### PR TITLE
Integrate Atom Linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,10 @@ Automatically build your project inside your new favorite editor, Atom.
 #### Automatically extract targets - here with [build-make](https://github.com/AtomBuild/atom-build-make).
 ![targets](https://noseglid.github.io/targets-make.gif)
 
-#### Match errors and go directly to offending code
+#### Match errors and go directly to offending code - with [Atom Linter](https://atom.io/packages/linter).
 ![error matching](https://noseglid.github.io/error-match.gif)
+
+(You can also use keyboard shortcuts to go to errors if you don't like Atom Linter, or want to keep package dependencies to a minimum).
 
 ## Build providers
 **[Full list of build providers](https://atombuild.github.io)**

--- a/README.md
+++ b/README.md
@@ -24,20 +24,14 @@ Automatically build your project inside your new favorite editor, Atom.
 #### Builds your project - configure it your way
 ![work work](https://noseglid.github.io/build.gif)
 
-#### Automatically extract targets - here with [build-gulp](https://github.com/AtomBuild/atom-build-gulp).
-![targets](https://noseglid.github.io/targets.gif)
+#### Automatically extract targets - here with [build-make](https://github.com/AtomBuild/atom-build-make).
+![targets](https://noseglid.github.io/targets-make.gif)
 
 #### Match errors and go directly to offending code
 ![error matching](https://noseglid.github.io/error-match.gif)
 
 ## Build providers
-** [AtomBuilds homepage](https://atombuild.github.io) holds a comprehensive list of available build providers. **
-
-The best way to use this `build` packages is via a build provider.
-Build providers are plugins to `build` which enables specific build tools (such as `GNU Make`, `gradle`, `gulp`, etc).
-
-Build providers can be downloaded via Atoms package manager and installed as
-any other package.
+**[Full list of build providers](https://atombuild.github.io)**
 
 <a name="build-command"></a>
 ### Specify a custom build command
@@ -133,7 +127,7 @@ correct file, row and column of the error. For instance:
 1 error generated.
 ```
 
-Would be matched with the regular expression: `\n(?<file>[\\/0-9a-zA-Z\\._]+):(?<line>\\d+):(?<col>\\d+)`.
+Would be matched with the regular expression: `(?<file>[\\/0-9a-zA-Z\\._]+):(?<line>\\d+):(?<col>\\d+):\\s+(?<message>.+)`.
 After the build has failed, pressing `cmd-alt-g` (OS X) or `f4` (Linux/Windows), `a.c` would be
 opened and the cursor would be placed at row 4, column 26.
 
@@ -145,18 +139,26 @@ The following named groups can be matched from the output:
   * `file` - **[required]** the file to open. May be relative `cwd` or absolute. `(?<file> RE)`.
   * `line` - *[optional]* the line the error resides on. `(?<line> RE)`.
   * `col` - *[optional]* the column the error resides on. `(?<col> RE)`.
+  * `message` - *[optional]* Catch the humanized error message. `(?<message> RE)`.
 
-Since the regular expressions are written in a JSON file, backslashes must be escaped.
+Backslashes must be escaped, thus the double `\\` everywhere.
 
 The `file` should be relative the `cwd` specified. If no `cwd` has been specified, then
 the `file` should be relative the project root (e.g. the top most directory shown in the
 Atom Editor).
 
 If your build outputs multiple errors, all will be matched. Press `cmd-alt-g` (OS X) or `ctrl-alt-g` (Linux/Windows)
-to cycle through the errors (in the order they appear, first on stderr then on stdout).
+to cycle through the errors (in the order they appear, first on stderr then on stdout), or you can use the
+Atom Linter integration discussed in the next section.
 
 Often, the first error is the most interesting since other errors tend to be secondary faults caused by that first one.
 To jump to the first error you can use `cmd-alt-h` (OS X) or `shift-f4` (Linux/Windows) at any point to go to the first error.
+
+### Error matching and Atom Linter
+
+Install [Atom Linter](https://atom.io/packages/linter) and all your matched errors will listed in a neat panel.
+
+![Linter integration](https://noseglid.github.io/build-linter.png)
 
 ## Analytics
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -17,6 +17,7 @@ export default {
     this.targetsLoading = {};
     this.targetsSubscriptions = {};
     this.tools = [ require('./atom-build') ];
+    this.linter = null;
 
     const BuildView = require('./build-view');
     this.buildView = new BuildView();
@@ -78,6 +79,7 @@ export default {
 
     this.statusBarView && this.statusBarView.destroy();
     this.buildView && this.buildView.destroy();
+    this.linter && this.linter.dispose();
 
     clearTimeout(this.finishedTimer);
   },
@@ -211,6 +213,7 @@ export default {
   startNewBuild(source, atomCommandName) {
     const BuildError = require('./build-error');
     const p = require('./utils').activePath();
+    this.linter && this.linter.deleteMessages();
 
     Promise.resolve(this.targets[p]).then(targets => {
       if (!targets || 0 === targets.length) {
@@ -290,6 +293,14 @@ export default {
         if (atom.config.get('build.matchedErrorFailsBuild')) {
           success = success && !this.errorMatcher.hasMatch();
         }
+
+        this.linter && this.linter.setMessages(this.errorMatcher.getMatches().map(match => ({
+          type: 'Error',
+          text: match.message || 'Error from build',
+          filePath: match.file,
+          range: [[match.line - 1, match.col - 1], [match.line - 1, match.col - 1]]
+        })));
+
         this.buildView.buildFinished(success);
         this.statusBarView && this.statusBarView.setBuildSuccess(success);
 
@@ -397,6 +408,10 @@ export default {
     } else {
       this.buildView.reset();
     }
+  },
+
+  consumeLinterRegistry(registry) {
+    this.linter = registry.register({ name: 'Build Linter' });
   },
 
   consumeBuilder(builder) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -91,6 +91,7 @@ export default {
 
   refreshTargets(refreshPaths) {
     refreshPaths = refreshPaths || atom.project.getPaths();
+    console.log('refreshing!');
 
     const pathPromise = refreshPaths.map((p) => {
       this.targetsLoading[p] = true;
@@ -362,6 +363,7 @@ export default {
   },
 
   build(source, event) {
+    console.log('building');
     clearTimeout(this.finishedTimer);
 
     this.doSaveConfirm(this.unsavedTextEditors(), () => {

--- a/lib/build.js
+++ b/lib/build.js
@@ -411,7 +411,7 @@ export default {
   },
 
   consumeLinterRegistry(registry) {
-    this.linter = registry.register({ name: 'Build Linter' });
+    this.linter = registry.register({ name: 'Build' });
   },
 
   consumeBuilder(builder) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -91,7 +91,6 @@ export default {
 
   refreshTargets(refreshPaths) {
     refreshPaths = refreshPaths || atom.project.getPaths();
-    console.log('refreshing!');
 
     const pathPromise = refreshPaths.map((p) => {
       this.targetsLoading[p] = true;
@@ -363,7 +362,6 @@ export default {
   },
 
   build(source, event) {
-    console.log('building');
     clearTimeout(this.finishedTimer);
 
     this.doSaveConfirm(this.unsavedTextEditors(), () => {

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -117,4 +117,8 @@ export default class ErrorMatcher extends EventEmitter {
   hasMatch() {
     return 0 !== this.currentMatch.length;
   }
+
+  getMatches() {
+    return this.currentMatch;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
       "versions": {
         "^1.0.0": "consumeStatusBar"
       }
+    },
+    "linter-indie": {
+      "versions": {
+        "1.0.0": "consumeLinterRegistry"
+      }
     }
   },
   "scripts": {

--- a/spec/build-spec.js
+++ b/spec/build-spec.js
@@ -5,6 +5,7 @@ import path from 'path';
 import temp from 'temp';
 import specHelpers from 'atom-build-spec-helpers';
 import os from 'os';
+import { sleep, cat, shellCmd, waitTime } from './helpers';
 
 describe('Build', () => {
   const goodAtomBuildfile = __dirname + '/fixture/.atom-build.json';
@@ -18,11 +19,6 @@ describe('Build', () => {
 
   let directory = null;
   let workspaceElement = null;
-  const isWin = process.platform === 'win32';
-  const sleep = (duration) => isWin ? `ping 127.0.0.1 -n ${duration} > NUL` : `sleep ${duration}`;
-  const cat = () => isWin ? 'type' : 'cat';
-  const shellCmd = isWin ? 'cmd /C' : '/bin/sh -c';
-  const waitTime = process.env.CI ? 2400 : 200;
 
   temp.track();
 

--- a/spec/build-view-spec.js
+++ b/spec/build-view-spec.js
@@ -4,12 +4,12 @@ import fs from 'fs-extra';
 import temp from 'temp';
 import specHelpers from 'atom-build-spec-helpers';
 import os from 'os';
+import { sleep } from './helpers';
 
 describe('BuildView', () => {
   const originalHomedirFn = os.homedir;
   let directory = null;
   let workspaceElement = null;
-  const sleep = (duration) => process.platform === 'win32' ? `ping 127.0.0.1 -n ${duration} > NUL` : `sleep ${duration}`;
 
   temp.track();
 

--- a/spec/fixture/.atom-build.error-match-multiple.json
+++ b/spec/fixture/.atom-build.error-match-multiple.json
@@ -1,4 +1,4 @@
 {
-	"cmd": "echo 'file:.atom-build.json,line:3,column:8 && echo file:.atom-build.json,line:2,column:5' && exit 1",
+	"cmd": "echo file:.atom-build.json,line:3,column:8 && echo file:.atom-build.json,line:2,column:5 && exit 1",
 	"errorMatch": "file:(?<file>[^,]+),line:(?<line>\\d+),column:(?<col>\\d+)"
 }

--- a/spec/fixture/.atom-build.error-match.message.json
+++ b/spec/fixture/.atom-build.error-match.message.json
@@ -1,4 +1,4 @@
 {
-	"cmd": "echo \"file:.atom-build.json,line:3,column:8: very bad things\" && exit 1",
+	"cmd": "echo file:.atom-build.json,line:3,column:8: very bad things&& exit 1",
 	"errorMatch": "file:(?<file>[^,]+),line:(?<line>\\d+),column:(?<col>\\d+):\\s+(?<message>.+)"
 }

--- a/spec/fixture/.atom-build.error-match.message.json
+++ b/spec/fixture/.atom-build.error-match.message.json
@@ -1,4 +1,4 @@
 {
-	"cmd": "echo 'file:.atom-build.json,line:3,column:8: very bad things' && exit 1",
+	"cmd": "echo file:.atom-build.json,line:3,column:8: very bad things && exit 1",
 	"errorMatch": "file:(?<file>[^,]+),line:(?<line>\\d+),column:(?<col>\\d+):\\s+(?<message>.+)"
 }

--- a/spec/fixture/.atom-build.error-match.message.json
+++ b/spec/fixture/.atom-build.error-match.message.json
@@ -1,4 +1,4 @@
 {
-	"cmd": "echo file:.atom-build.json,line:3,column:8: very bad things && exit 1",
+	"cmd": "echo \"file:.atom-build.json,line:3,column:8: very bad things\" && exit 1",
 	"errorMatch": "file:(?<file>[^,]+),line:(?<line>\\d+),column:(?<col>\\d+):\\s+(?<message>.+)"
 }

--- a/spec/fixture/.atom-build.error-match.message.json
+++ b/spec/fixture/.atom-build.error-match.message.json
@@ -1,0 +1,4 @@
+{
+	"cmd": "echo 'file:.atom-build.json,line:3,column:8: very bad things' && exit 1",
+	"errorMatch": "file:(?<file>[^,]+),line:(?<line>\\d+),column:(?<col>\\d+):\\s+(?<message>.+)"
+}

--- a/spec/fixture/atom-build-spec-linter/atom-build-spec-linter.js
+++ b/spec/fixture/atom-build-spec-linter/atom-build-spec-linter.js
@@ -1,0 +1,33 @@
+'use babel';
+
+class Linter {
+  constructor() {
+    this.messages = [];
+  }
+  dispose() {}
+  setMessages(msg) {
+    this.messages = this.messages.concat(msg);
+  }
+  deleteMessages() {
+    this.messages = [];
+  }
+}
+
+module.exports = {
+  activate: () => {},
+  provideIndie: () => ({
+    register: (obj) => {
+      this.registered = obj;
+      this.linter = new Linter();
+      return this.linter;
+    }
+  }),
+
+  hasRegistered: () => {
+    return this.registered !== undefined;
+  },
+
+  getLinter: () => {
+    return this.linter;
+  }
+};

--- a/spec/fixture/atom-build-spec-linter/package.json
+++ b/spec/fixture/atom-build-spec-linter/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "atom-build-spec-linter",
+  "main": "atom-build-spec-linter",
+  "providedServices": {
+    "linter-indie": {
+      "versions": {
+        "1.0.0": "provideIndie"
+      }
+    }
+  }
+}

--- a/spec/helpers.js
+++ b/spec/helpers.js
@@ -1,0 +1,7 @@
+'use babel';
+
+export const isWin = process.platform === 'win32';
+export const sleep = (duration) => isWin ? `ping 127.0.0.1 -n ${duration} > NUL` : `sleep ${duration}`;
+export const cat = () => isWin ? 'type' : 'cat';
+export const shellCmd = isWin ? 'cmd /C' : '/bin/sh -c';
+export const waitTime = process.env.CI ? 2400 : 200;

--- a/spec/linter-intergration-spec.js
+++ b/spec/linter-intergration-spec.js
@@ -1,0 +1,104 @@
+'use babel';
+
+import fs from 'fs-extra';
+import temp from 'temp';
+import specHelpers from 'atom-build-spec-helpers';
+
+describe('Linter Integration', () => {
+  let directory = null;
+  let workspaceElement = null;
+  let dummyPackage = null;
+
+  temp.track();
+
+  beforeEach(() => {
+    directory = fs.realpathSync(temp.mkdirSync({ prefix: 'atom-build-spec-' }));
+    atom.project.setPaths([ directory ]);
+
+    atom.config.set('build.buildOnSave', false);
+    atom.config.set('build.panelVisibility', 'Toggle');
+    atom.config.set('build.saveOnBuild', false);
+    atom.config.set('build.scrollOnError', false);
+    atom.config.set('build.notificationOnRefresh', true);
+    atom.config.set('editor.fontSize', 14);
+
+    jasmine.unspy(window, 'setTimeout');
+    jasmine.unspy(window, 'clearTimeout');
+
+    runs(() => {
+      workspaceElement = atom.views.getView(atom.workspace);
+      jasmine.attachToDOM(workspaceElement);
+    });
+
+    waitsForPromise(() => {
+      return Promise.resolve()
+        .then(() => atom.packages.activatePackage('build'))
+        .then(() => atom.packages.activatePackage(`${__dirname}/fixture/atom-build-spec-linter/`))
+        .then(() => dummyPackage = atom.packages.getActivePackage('atom-build-spec-linter').mainModule);
+    });
+  });
+
+  afterEach(() => {
+    fs.removeSync(directory);
+  });
+
+  describe('when error matching and linter is activated', () => {
+    it('should push those errors to the linter', () => {
+      expect(dummyPackage.hasRegistered()).toEqual(true);
+      fs.writeFileSync(`${directory}/.atom-build.json`, fs.readFileSync(`${__dirname}/fixture/.atom-build.error-match-multiple.json`));
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
+      waitsFor(() => {
+        return workspaceElement.querySelector('.build .title') &&
+          workspaceElement.querySelector('.build .title').classList.contains('error');
+      });
+
+      runs(() => {
+        const linter = dummyPackage.getLinter();
+        expect(linter.messages).toEqual([
+          {
+            filePath: '.atom-build.json',
+            range: [ [2, 7], [2, 7] ],
+            text: 'Error from build',
+            type: 'Error'
+          },
+          {
+            filePath: '.atom-build.json',
+            range: [ [1, 4], [1, 4] ],
+            text: 'Error from build',
+            type: 'Error'
+          }
+        ]);
+      });
+    });
+
+    fit('should parse `message` and include that to linter', () => {
+      expect(dummyPackage.hasRegistered()).toEqual(true);
+      fs.writeFileSync(`${directory}/.atom-build.json`, fs.readFileSync(`${__dirname}/fixture/.atom-build.error-match.message.json`));
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
+      waitsFor(() => {
+        return workspaceElement.querySelector('.build .title') &&
+          workspaceElement.querySelector('.build .title').classList.contains('error');
+      });
+
+      runs(() => {
+        const linter = dummyPackage.getLinter();
+        expect(linter.messages).toEqual([
+          {
+            filePath: '.atom-build.json',
+            range: [ [2, 7], [2, 7] ],
+            text: 'very bad things',
+            type: 'Error'
+          }
+        ]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
This gives a nice overview of all build errors.

Tasks left before this is mergable
  - [x] implement the primary integration
  - [x] specs
  - ~~[ ] scroll the build output to the matched error~~: There doesn't seem to be any support in the linter for this. Issue created: https://github.com/steelbrain/linter/issues/1106. Will fix that in a separate PR )
  - [x] document the 'message' entry in error matcher
  - [x] document that the linter might be cool to have installed

Fixes #346 