### PR TITLE
Don't normalize cmd

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -250,7 +250,7 @@ export default {
       if (target.sh) {
         this.child = require('child_process').spawn(
           shCmd,
-          [ shCmdArg, [ require('path').normalize(exec) ].concat(args).join(' ')],
+          [ shCmdArg, [ exec ].concat(args).join(' ')],
           { cwd: cwd, env: env }
         );
       } else {


### PR DESCRIPTION
Fix execution of commands on Windows which contain `/`.

Try the following `.atom-build.yml` on Windows:

```
cmd: explorer https://github.com/noseglid/atom-build
```

Expected result: Opens the correct URL in the browser.
Actual result: Tries to open `https:\github.com\noseglid\atom-build`.