### PR TITLE
Live error match

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -221,6 +221,9 @@ export default {
       range: [[match.line - 1, (match.col || 1) - 1], [match.line - 1, (match.col || 1) - 1]]
     }));
     this.linter.setMessages(matches);
+    if (matches.length > 0 && atom.config.get('build.scrollOnError')) {
+      this.errorMatcher.matchLast();
+    }
   },
 
   startNewBuild(source, atomCommandName) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -286,11 +286,10 @@ export default {
       let stdout = '';
       let stderr = '';
       let liveErroMatchQueue = '';
-      var liveErroMatchHandle = target.liveErrorMatch ? function(d) {
+      let liveErroMatchHandle = target.liveErrorMatch ? function (d) {
         d = liveErroMatchQueue + d;
         liveErroMatchQueue = '';
-        var index = d.lastIndexOf('\n');
-        console.log('liveErroMatchHandle', liveErroMatchQueue, d.length, index);
+        let index = d.lastIndexOf('\n');
         if (index >= 0 && index === d.length - 1) {
           that.errorMatcher.parseAdd(d);
         } else {
@@ -298,14 +297,14 @@ export default {
           that.errorMatcher.parseAdd(d.substring(0, index));
         }
         that.updateErrorLinter();
-      } : function() {};
+      } : function () {};
       this.child.stdout.setEncoding('utf8');
       this.child.stderr.setEncoding('utf8');
-      this.child.stdout.on('data', function(d) {
+      this.child.stdout.on('data', function (d) {
         stdout += d;
         liveErroMatchHandle(d);
       });
-      this.child.stderr.on('data', function(d) {
+      this.child.stderr.on('data', function (d) {
         stderr += d;
         liveErroMatchHandle(d);
       });
@@ -329,7 +328,6 @@ export default {
         if (!target.liveErrorMatch) {
           this.errorMatcher.parse(stdout + stderr);
         }
-
 
         let success = (0 === exitCode);
         if (atom.config.get('build.matchedErrorFailsBuild')) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -211,13 +211,16 @@ export default {
   },
 
   updateErrorLinter() {
+    if (!this.linter) {
+      return;
+    }
     const matches = this.errorMatcher.getMatches().map(match => ({
       type: 'error',
       text: match.message || 'Error from build',
       filePath: match.file,
       range: [[match.line - 1, (match.col || 1) - 1], [match.line - 1, (match.col || 1) - 1]]
     }));
-    this.linter && this.linter.setMessages(matches);
+    this.linter.setMessages(matches);
   },
 
   startNewBuild(source, atomCommandName) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -251,7 +251,7 @@ export default {
         if (target.preBuild && typeof target.preBuild === 'function') {
           return target.preBuild();
         }
-      }).then(() => target);
+      }).then( () => target );
     }).then(target => {
       const replace = require('./utils').replace;
       const env = Object.assign({}, process.env, target.env);
@@ -285,21 +285,29 @@ export default {
 
       let stdout = '';
       let stderr = '';
+      let liveErroMatchQueue = '';
+      var liveErroMatchHandle = target.liveErrorMatch ? function(d) {
+        d = liveErroMatchQueue + d;
+        liveErroMatchQueue = '';
+        var index = d.lastIndexOf('\n');
+        console.log('liveErroMatchHandle', liveErroMatchQueue, d.length, index);
+        if (index >= 0 && index === d.length - 1) {
+          that.errorMatcher.parseAdd(d);
+        } else {
+          liveErroMatchQueue = d.substring(index + 1);
+          that.errorMatcher.parseAdd(d.substring(0, index));
+        }
+        that.updateErrorLinter();
+      } : function() {};
       this.child.stdout.setEncoding('utf8');
       this.child.stderr.setEncoding('utf8');
       this.child.stdout.on('data', function(d) {
-          stdout += d;
-          if (target.liveErrorMatch) {
-            that.errorMatcher.parseAdd(d);
-            that.updateErrorLinter();
-          }
+        stdout += d;
+        liveErroMatchHandle(d);
       });
       this.child.stderr.on('data', function(d) {
-          stderr += d;
-          if (target.liveErrorMatch) {
-            that.errorMatcher.parseAdd(d);
-            that.updateErrorLinter();
-          }
+        stderr += d;
+        liveErroMatchHandle(d);
       });
       this.child.stdout.pipe(this.buildView.terminal);
       this.child.stderr.pipe(this.buildView.terminal);
@@ -319,7 +327,7 @@ export default {
 
       this.child.on('close', (exitCode) => {
         if (!target.liveErrorMatch) {
-            this.errorMatcher.parse(stdout + stderr);
+          this.errorMatcher.parse(stdout + stderr);
         }
 
 
@@ -327,8 +335,6 @@ export default {
         if (atom.config.get('build.matchedErrorFailsBuild')) {
           success = success && !this.errorMatcher.hasMatch();
         }
-
-
 
         this.buildView.buildFinished(success);
         this.statusBarView && this.statusBarView.setBuildSuccess(success);
@@ -440,7 +446,6 @@ export default {
   },
 
   consumeLinterRegistry(registry) {
-    console.log('consumeLinterRegistry');
     this.linter = registry.register({ name: 'Build' });
   },
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -210,6 +210,16 @@ export default {
     });
   },
 
+  updateErrorLinter() {
+    const matches = this.errorMatcher.getMatches().map(match => ({
+      type: 'error',
+      text: match.message || 'Error from build',
+      filePath: match.file,
+      range: [[match.line - 1, (match.col || 1) - 1], [match.line - 1, (match.col || 1) - 1]]
+    }));
+    this.linter && this.linter.setMessages(matches);
+  },
+
   startNewBuild(source, atomCommandName) {
     const BuildError = require('./build-error');
     const p = require('./utils').activePath();

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -71,8 +71,8 @@ export default class ErrorMatcher extends EventEmitter {
     const self = this;
     const matchFunction = function (match, i, string, regex) {
       match.id = 'error-match-' + self.regex.indexOf(regex) + '-' + i;
-      match.line = parseInt(match.line);
-      match.col = parseInt(match.col);
+      match.line = parseInt(match.line, 10);
+      match.col = parseInt(match.col, 10);
       this.push(match);
     };
     this.regex.forEach((regex) => {
@@ -130,7 +130,7 @@ export default class ErrorMatcher extends EventEmitter {
   matchLast() {
     require('./google-analytics').sendEvent('errorMatch', 'last');
 
-    focusMatch(this.currentMatch[this.currentMatch.length - 1]);
+    this.focusMatch(this.currentMatch[this.currentMatch.length - 1]);
   }
 
   hasMatch() {

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -68,6 +68,8 @@ export default class ErrorMatcher extends EventEmitter {
     const self = this;
     const matchFunction = function (match, i, string, regex) {
       match.id = 'error-match-' + self.regex.indexOf(regex) + '-' + i;
+      match.line = parseInt(match.line);
+      match.col = parseInt(match.col);
       this.push(match);
     };
     this.regex.forEach((regex) => {

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -25,26 +25,7 @@ export default class ErrorMatcher extends EventEmitter {
     this.goto(this.currentMatch[0].id);
   }
 
-  _gotoLast() {
-    if (0 === this.currentMatch.length) {
-      return;
-    }
-
-    this.goto(this.currentMatch[this.currentMatch.length - 1].id);
-  }
-
-  goto(id) {
-    const match = this.currentMatch.find(m => m.id === id);
-    if (!match) {
-      return this.emit('error', 'Can\'t find match with id ' + id);
-    }
-
-    // rotate to next match
-    while (this.currentMatch[0] !== match) {
-      this.currentMatch.push(this.currentMatch.shift());
-    }
-    this.currentMatch.push(this.currentMatch.shift());
-
+  focusMatch(match) {
     let file = match.file;
     if (!file) {
       return this.emit('error', 'Did not match any file. Don\'t know what to open.');
@@ -71,6 +52,21 @@ export default class ErrorMatcher extends EventEmitter {
     });
   }
 
+  goto(id) {
+    const match = this.currentMatch.find(m => m.id === id);
+    if (!match) {
+      return this.emit('error', 'Can\'t find match with id ' + id);
+    }
+
+    // rotate to next match
+    while (this.currentMatch[0] !== match) {
+      this.currentMatch.push(this.currentMatch.shift());
+    }
+    this.currentMatch.push(this.currentMatch.shift());
+
+    this.focus(match);
+  }
+
   _parse(output) {
     const self = this;
     const matchFunction = function (match, i, string, regex) {
@@ -85,7 +81,9 @@ export default class ErrorMatcher extends EventEmitter {
 
     this.currentMatch.sort((a, b) => a.index - b.index);
 
-    this.firstMatchId = (this.currentMatch.length > 0) ? this.currentMatch[0].id : null;
+    if (!this.firstMatchId) {
+      this.firstMatchId = (this.currentMatch.length > 0) ? this.currentMatch[0].id : null;
+    }
   }
 
   set(regex, cwd) {
@@ -112,9 +110,7 @@ export default class ErrorMatcher extends EventEmitter {
   }
 
   parseAdd(output) {
-    // console.log('parseAdd', output);
     this._parse(output);
-    // this._gotoLast();
   }
 
   match() {
@@ -129,6 +125,12 @@ export default class ErrorMatcher extends EventEmitter {
     if (this.firstMatchId) {
       this.goto(this.firstMatchId);
     }
+  }
+
+  matchLast() {
+    require('./google-analytics').sendEvent('errorMatch', 'last');
+
+    focusMatch(this.currentMatch[this.currentMatch.length - 1]);
   }
 
   hasMatch() {


### PR DESCRIPTION
In my dev env (Titanium Mobile), we run javascript interpreted code on the iOS/Android simulators.
Which means that error can occur in real time.
Also the build never really end until we stop the simulator.
So it means that error wont get catched in the system used now.

So i added a target option ```liveErrorMatch``` which will allow live error matching.
I created the pull request against the ```linter-integration``` branch to test it all.
I can report that it works very well!