### PR TITLE
don't rely on editor path

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -25,9 +25,8 @@ const activePath = () => {
       return false;
     }
 
-    return atom.project.getPaths()[0];
   }
-
+  return atom.project.getPaths()[0];
   /* otherwise, build the one in the root of the active editor */
   return atom.project.getPaths().sort((a, b) => (b.length - a.length)).find(p => {
     try {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,11 +24,10 @@ const activePath = () => {
     if (0 === atom.project.getPaths().length) {
       return false;
     }
-
+    return atom.project.getPaths()[0];
   }
-  return atom.project.getPaths()[0];
   /* otherwise, build the one in the root of the active editor */
-  return atom.project.getPaths().sort((a, b) => (b.length - a.length)).find(p => {
+  var result = atom.project.getPaths().sort((a, b) => (b.length - a.length)).find(p => {
     try {
       const realpath = fs.realpathSync(p);
       return textEditor.getPath().substr(0, realpath.length) === realpath;
@@ -37,6 +36,9 @@ const activePath = () => {
       return false;
     }
   });
+  //if we don't find a project path containing the edited file then
+  //return the first project path as default
+  return result || atom.project.getPaths()[0];
 };
 
 const getDefaultSettings = (cwd, setting) => {


### PR DESCRIPTION
I faced that issue where i was editing a file outside of the project and the build was not working.
I think the build should be related to the opened project and not the editing file.

I am not sure of the right way to fix that but that dirty fix make it works in all cases