### PR TITLE
Option to hide panel heading

### DIFF
--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -61,6 +61,9 @@ export default class BuildView extends View {
 
     atom.config.observe('build.panelVisibility', ::this.visibleFromConfig);
     atom.config.observe('build.panelOrientation', ::this.orientationFromConfig);
+    atom.config.observe('build.hidePanelHeading', (hide) => {
+      hide && this.panelHeading.hide() || this.panelHeading.show();
+    });
     atom.config.observe('build.overrideThemeColors', (override) => {
       this.output.removeClass('override-theme');
       override && this.output.addClass('override-theme');
@@ -225,16 +228,11 @@ export default class BuildView extends View {
       this.attach();
     }
 
-    this.panelHeading.get(0).removeEventListener('mousedown', this.resizeStarted);
     this.resizer.get(0).removeEventListener('mousedown', this.resizeStarted);
 
     switch (orientation) {
-      case 'Bottom':
-        this.panelHeading.get(0).addEventListener('mousedown', this.resizeStarted);
-        this.get(0).style.width = null;
-        break;
-
       case 'Top':
+      case 'Bottom':
         this.get(0).style.width = null;
         this.resizer.get(0).addEventListener('mousedown', this.resizeStarted);
         break;

--- a/lib/config.js
+++ b/lib/config.js
@@ -9,68 +9,75 @@ export default {
     enum: [ 'Toggle', 'Keep Visible', 'Show on Error', 'Hidden' ],
     order: 1
   },
+  hidePanelHeading: {
+    title: 'Hide panel heading',
+    description: 'Set whether to hide the build command and control buttons in the build panel',
+    type: 'boolean',
+    default: false,
+    order: 2
+  },
   buildOnSave: {
     title: 'Automatically build on save',
     description: 'Automatically build your project each time an editor is saved.',
     type: 'boolean',
     default: false,
-    order: 2
+    order: 3
   },
   saveOnBuild: {
     title: 'Automatically save on build',
     description: 'Automatically save all edited files when triggering a build.',
     type: 'boolean',
     default: false,
-    order: 3
+    order: 4
   },
   matchedErrorFailsBuild: {
     title: 'Any matched error will fail the build',
     description: 'Even if the build has a return code of zero it is marked as "failed" if any error is being matched in the output.',
     type: 'boolean',
     default: true,
-    order: 4
+    order: 5
   },
   scrollOnError: {
     title: 'Automatically scroll on build error',
     description: 'Automatically scroll to first matched error when a build failed.',
     type: 'boolean',
     default: false,
-    order: 5
+    order: 6
   },
   stealFocus: {
     title: 'Steal Focus',
     description: 'Steal focus when opening build panel.',
     type: 'boolean',
     default: true,
-    order: 6
+    order: 7
   },
   overrideThemeColors: {
     title: 'Override Theme Colors',
     description: 'Override theme background- and text color inside the terminal',
     type: 'boolean',
     default: true,
-    order: 7
+    order: 8
   },
   selectTriggers: {
     title: 'Selecting new target triggers the build',
     description: 'When selecting a new target (through status-bar, cmd-alt-t, etc), the newly selected target will be triggered.',
     type: 'boolean',
     default: true,
-    order: 8
+    order: 9
   },
   notificationOnRefresh: {
     title: 'Show notification when targets are refreshed',
     description: 'When targets are refreshed a notification with information about the number of targets will be displayed.',
     type: 'boolean',
     default: false,
-    order: 9
+    order: 10
   },
   beepWhenDone: {
     title: 'Beep when the build completes',
     description: 'Make a "beep" notification sound when the build is complete - in success or failure.',
     type: 'boolean',
     default: false,
-    order: 10
+    order: 11
   },
   panelOrientation: {
     title: 'Panel Orientation',
@@ -78,7 +85,7 @@ export default {
     type: 'string',
     default: 'Bottom',
     enum: [ 'Bottom', 'Top', 'Left', 'Right' ],
-    order: 11
+    order: 12
   },
   statusBar: {
     title: 'Status Bar',
@@ -86,13 +93,13 @@ export default {
     type: 'string',
     default: 'Left',
     enum: [ 'Left', 'Right', 'Disable' ],
-    order: 12
+    order: 13
   },
   statusBarPriority: {
     title: 'Priority on Status Bar',
     description: 'Lower priority tiles are placed further to the left/right, depends on where you choose to place Status Bar.',
     type: 'number',
     default: -1000,
-    order: 13
+    order: 14
   }
 };

--- a/spec/build-view-spec.js
+++ b/spec/build-view-spec.js
@@ -197,4 +197,56 @@ describe('BuildView', () => {
       });
     });
   });
+
+  describe('when hidePanelHeading is set', () => {
+    beforeEach(() => {
+      atom.config.set('build.hidePanelHeading', true);
+    });
+
+    afterEach(() => {
+      atom.config.set('build.hidePanelHeading', false);
+    });
+
+    it('should not show the panel heading', () => {
+      expect(workspaceElement.querySelector('.build')).not.toExist();
+
+      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
+        cmd: 'echo hello && exit 1'
+      }));
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
+      waitsFor(() => {
+        return workspaceElement.querySelector('.build');
+      });
+
+      runs(() => {
+        expect(workspaceElement.querySelector('.build .heading')).toBeHidden();
+      });
+    });
+
+    it('should show the heading when hidden is disabled', () => {
+      expect(workspaceElement.querySelector('.build')).not.toExist();
+
+      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
+        cmd: 'echo hello && exit 1'
+      }));
+
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
+      waitsFor(() => {
+        return workspaceElement.querySelector('.build');
+      });
+
+      runs(() => {
+        expect(workspaceElement.querySelector('.build .heading')).toBeHidden();
+        atom.config.set('build.hidePanelHeading', false);
+        expect(workspaceElement.querySelector('.build .heading')).toBeVisible();
+      });
+    });
+  });
 });

--- a/styles/panel-top-bottom.less
+++ b/styles/panel-top-bottom.less
@@ -5,7 +5,6 @@ atom-panel.bottom .build {
   .resizer {
     cursor: row-resize;
     width: 100%;
-    bottom: 0;
   }
 
   .terminal {
@@ -13,11 +12,14 @@ atom-panel.bottom .build {
   }
 }
 
-atom-panel.bottom .build {
-  .heading {
-    cursor: row-resize;
-  }
+atom-panel.top .build {
   .resizer {
-    display: none;
+    bottom: 0;
+  }
+}
+
+atom-panel.bottom .build {
+  .resizer {
+    top: 0;
   }
 }


### PR DESCRIPTION
If content is not of interest, this gives more space to what
the user might deem important.

Also changed so `resizer` element is used in the bottom position too.

Fixes #357