### PR TITLE
Support for `.atom-build.js`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Supported formats and the name of the configuration file is
   * JSON: `.atom-build.json`
   * CSON: `.atom-build.cson`
   * YAML: `.atom-build.yml`
+  * JS: `.atom-build.js`
 
 Pick your favorite format, save that file in your project root, and specify exactly
 how your project is built (example in `json`)
@@ -81,6 +82,21 @@ systems).
 If `sh` is true, it will use a shell (e.g. `/bin/sh -c`) on unix/linux, and command (`cmd /S /C`)
 on windows.
 
+Using a JavaScript (JS) file gives you the additional benefit of being able to specify `preBuild` and `postBuild`. Keep in mind
+that the JavaScript file must `export` the configuration
+
+```javascript
+module.exports = {
+  cmd: "myCommand",
+  preBuild: function () {
+    console.log('This is run **before** the build command');
+  },
+  postBuild: function () {
+    console.log('This is run **after** the build command');
+  }
+};
+```
+
 <a name="custom-build-config"></a>
 #### Configuration options
 
@@ -96,6 +112,8 @@ Option            | Required       | Description
 `keymap`          | *[optional]*   | A keymap string as defined by [`Atom`](https://atom.io/docs/latest/behind-atom-keymaps-in-depth). Pressing this key combination will trigger the target. Examples: `ctrl-alt-k` or `cmd-U`.
 `atomCommandName` | *[optional]*   | Command name to register which should be on the form of `namespace:command`. Read more about [Atom CommandRegistry](https://atom.io/docs/api/v1.4.1/CommandRegistry). The command will be available in the command palette and can be trigger from there. If this is returned by a build provider, the command can programatically be triggered by [dispatching](https://atom.io/docs/api/v1.4.1/CommandRegistry#instance-dispatch).
 `targets`         | *[optional]*   | Additional targets which can be used to build variations of your project.
+`preBuild`        | *[optional]*   | **JS only**. A function which will be called *before* executing `cmd`. No arguments. `this` will be the build configuration.
+`postBuild`       | *[optional]*   | **JS only**. A function which will be called *after* executing `cmd`. A single argument `bool buildOutcome` indicating outcome of the running `cmd`. `this` will be the build configuration.
 
 #### Replacements
 
@@ -130,8 +148,8 @@ correct file, row and column of the error. For instance:
 ```
 
 Would be matched with the regular expression: `(?<file>[\\/0-9a-zA-Z\\._]+):(?<line>\\d+):(?<col>\\d+):\\s+(?<message>.+)`.
-After the build has failed, pressing `cmd-alt-g` (OS X) or `f4` (Linux/Windows), `a.c` would be
-opened and the cursor would be placed at row 4, column 26.
+After the build has failed, pressing `cmd-alt-g` (OS X) or `ctrl-alt-g` (Linux/Windows)
+(or `f4` on either platform), `a.c` would be opened and the cursor would be placed at row 4, column 26.
 
 Note the syntax for match groups. This is from the [XRegExp](http://xregexp.com/) package
 and has the syntax for named groups: `(?<name> RE )` where `name` would be the name of the group

--- a/lib/atom-build.js
+++ b/lib/atom-build.js
@@ -59,7 +59,7 @@ export default class CustomFile extends EventEmitter {
   }
 
   isEligible() {
-    const os = require('os')
+    const os = require('os');
     const fs = require('fs');
     const path = require('path');
     this.files = [].concat.apply([], [ 'json', 'cson', 'yml', 'js' ].map(ext => [

--- a/lib/atom-build.js
+++ b/lib/atom-build.js
@@ -8,6 +8,7 @@ function getConfig(file) {
   delete require.cache[realFile];
   switch (require('path').extname(file)) {
     case '.json':
+    case '.js':
       return require(realFile);
 
     case '.cson':
@@ -19,7 +20,7 @@ function getConfig(file) {
 }
 
 function createBuildConfig(build, name) {
-  return {
+  const conf = {
     name: 'Custom: ' + name,
     exec: build.cmd,
     env: build.env,
@@ -30,6 +31,16 @@ function createBuildConfig(build, name) {
     atomCommandName: build.atomCommandName,
     keymap: build.keymap
   };
+
+  if (typeof build.postBuild === 'function') {
+    conf.postBuild = build.postBuild;
+  }
+
+  if (typeof build.preBuild === 'function') {
+    conf.preBuild = build.preBuild;
+  }
+
+  return conf;
 }
 
 export default class CustomFile extends EventEmitter {
@@ -48,17 +59,13 @@ export default class CustomFile extends EventEmitter {
   }
 
   isEligible() {
-    const os = require('os');
+    const os = require('os')
     const fs = require('fs');
     const path = require('path');
-    this.files = [
-      path.join(this.cwd, '.atom-build.json'),
-      path.join(this.cwd, '.atom-build.cson'),
-      path.join(this.cwd, '.atom-build.yml'),
-      path.join(os.homedir(), '.atom-build.json'),
-      path.join(os.homedir(), '.atom-build.cson'),
-      path.join(os.homedir(), '.atom-build.yml')
-    ].filter(fs.existsSync);
+    this.files = [].concat.apply([], [ 'json', 'cson', 'yml', 'js' ].map(ext => [
+      path.join(this.cwd, `.atom-build.${ext}`),
+      path.join(os.homedir(), `.atom-build.${ext}`)
+    ])).filter(fs.existsSync);
     return 0 < this.files.length;
   }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -213,6 +213,7 @@ export default {
   startNewBuild(source, atomCommandName) {
     const BuildError = require('./build-error');
     const p = require('./utils').activePath();
+    let buildTitle = '';
     this.linter && this.linter.deleteMessages();
 
     Promise.resolve(this.targets[p]).then(targets => {
@@ -231,11 +232,11 @@ export default {
         throw new BuildError('Invalid build file.', 'No executable command specified.');
       }
 
-      return Promise.resolve().then(() => {
-        if (target.preBuild && typeof target.preBuild === 'function') {
-          return target.preBuild();
-        }
-      }).then(() => target);
+      this.statusBarView && this.statusBarView.buildStarted();
+      this.buildView.buildStarted();
+      this.buildView.setHeading('Running preBuild...');
+
+      return Promise.resolve(target.preBuild ? target.preBuild() : null).then(() => target);
     }).then(target => {
       const replace = require('./utils').replace;
       const env = Object.assign({}, process.env, target.env);
@@ -250,6 +251,10 @@ export default {
       const shCmd = isWin ? 'cmd' : '/bin/sh';
       const shCmdArg = isWin ? '/C' : '-c';
 
+      // Store this as we need to re-set it after postBuild
+      buildTitle = [ (target.sh ? `${shCmd} ${shCmdArg} ${exec}` : exec ), ...args, '\n'].join(' ');
+
+      this.buildView.setHeading(buildTitle);
       if (target.sh) {
         this.child = require('child_process').spawn(
           shCmd,
@@ -287,6 +292,7 @@ export default {
       });
 
       this.child.on('close', (exitCode) => {
+        this.child = null;
         this.errorMatcher.set(target.errorMatch, cwd, stdout + stderr);
 
         let success = (0 === exitCode);
@@ -301,34 +307,29 @@ export default {
           range: [[match.line - 1, match.col - 1], [match.line - 1, match.col - 1]]
         })));
 
-        this.buildView.buildFinished(success);
-        this.statusBarView && this.statusBarView.setBuildSuccess(success);
-
         if (atom.config.get('build.beepWhenDone')) {
           atom.beep();
         }
 
-        if (success) {
-          require('./google-analytics').sendEvent('build', 'succeeded');
-          this.finishedTimer = setTimeout(() => {
-            this.buildView.detach();
-          }, 1200);
-        } else {
-          if (atom.config.get('build.scrollOnError')) {
-            this.errorMatcher.matchFirst();
+        this.buildView.setHeading('Running postBuild...');
+        return Promise.resolve(target.postBuild ? target.postBuild(success) : null).then(() => {
+          this.buildView.setHeading(buildTitle);
+
+          this.buildView.buildFinished(success);
+          this.statusBarView && this.statusBarView.setBuildSuccess(success);
+          if (success) {
+            require('./google-analytics').sendEvent('build', 'succeeded');
+            this.finishedTimer = setTimeout(() => {
+              this.buildView.detach();
+            }, 1200);
+          } else {
+            if (atom.config.get('build.scrollOnError')) {
+              this.errorMatcher.matchFirst();
+            }
+            require('./google-analytics').sendEvent('build', 'failed');
           }
-          require('./google-analytics').sendEvent('build', 'failed');
-        }
-        this.child = null;
-
-        if (target.postBuild && typeof target.postBuild === 'function') {
-          return target.postBuild(success);
-        }
+        });
       });
-
-      this.statusBarView && this.statusBarView.buildStarted();
-      this.buildView.buildStarted();
-      this.buildView.setHeading([ (target.sh ? `${shCmd} ${shCmdArg} ${exec}` : exec ), ...args, '\n'].join(' '));
     }).catch((err) => {
       if (err instanceof BuildError) {
         if (source === 'save') {

--- a/spec/custom-provider-spec.js
+++ b/spec/custom-provider-spec.js
@@ -112,4 +112,20 @@ describe('custom provider', () => {
       });
     });
   });
+
+  describe('when .atom-build.js exists', () => {
+    fit('it should provide targets', () => {
+      fs.writeFileSync(`${directory}.atom-build.js`, fs.readFileSync(`${__dirname}/fixture/.atom-build.js`));
+      expect(builder.isEligible()).toEqual(true);
+
+      waitsForPromise(() => {
+        return Promise.resolve(builder.settings()).then(settings => {
+          const s = settings[0];
+          expect(s.exec).toEqual('echo');
+          expect(s.args).toEqual([ 'hello', 'world', 'from', 'js' ]);
+          expect(s.name).toEqual('Custom: from js');
+        });
+      });
+    });
+  });
 });

--- a/spec/custom-provider-spec.js
+++ b/spec/custom-provider-spec.js
@@ -114,7 +114,7 @@ describe('custom provider', () => {
   });
 
   describe('when .atom-build.js exists', () => {
-    fit('it should provide targets', () => {
+    it('it should provide targets', () => {
       fs.writeFileSync(`${directory}.atom-build.js`, fs.readFileSync(`${__dirname}/fixture/.atom-build.js`));
       expect(builder.isEligible()).toEqual(true);
 

--- a/spec/fixture/.atom-build.js
+++ b/spec/fixture/.atom-build.js
@@ -1,0 +1,5 @@
+module.exports = {
+  cmd: 'echo',
+  args: [ 'hello', 'world', 'from', 'js' ],
+  name: 'from js'
+};


### PR DESCRIPTION
Support for defining `.atom-build.js`.

This format support functions so that `preBuild` and `postBuild` can be defined.
The configuration must be `module.exports`'d.

Need

  * [x] specs
  * [x] documentation

Fixes #362 
