### PR TITLE
Linter report no row or col

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -298,7 +298,10 @@ export default {
           type: 'Error',
           text: match.message || 'Error from build',
           filePath: match.file,
-          range: [[match.line - 1, match.col - 1], [match.line - 1, match.col - 1]]
+          range: [
+            [ (match.line || 1) - 1, (match.col || 1) - 1 ],
+            [ (match.line || 1) - 1, (match.col || 1) - 1]
+          ]
         })));
 
         this.buildView.buildFinished(success);


### PR DESCRIPTION
Only `file` is required by the errorMatcher API.
The linter integration should therefore report
the first row or the first column if the value is missing.
This will place the corsor "as correct as possible".

Fixes #364