### PR TITLE
support relative paths in linter + spans that span multiple characters/lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,10 @@ matched by the regular expression `RE`.
 
 The following named groups can be matched from the output:
   * `file` - **[required]** the file to open. May be relative `cwd` or absolute. `(?<file> RE)`.
-  * `line` - *[optional]* the line the error resides on. `(?<line> RE)`.
-  * `col` - *[optional]* the column the error resides on. `(?<col> RE)`.
+  * `line` - *[optional]* the line the error starts on. `(?<line> RE)`.
+  * `col` - *[optional]* the column the error starts on. `(?<col> RE)`.
+  * `line_end` - *[optional]* the line the error ends on. `(?<line_end> RE)`.
+  * `col_end` - *[optional]* the column the error ends on. `(?<col_end> RE)`.
   * `message` - *[optional]* Catch the humanized error message. `(?<message> RE)`.
 
 Backslashes must be escaped, thus the double `\\` everywhere.

--- a/lib/build.js
+++ b/lib/build.js
@@ -300,10 +300,11 @@ export default {
           success = success && !this.errorMatcher.hasMatch();
         }
 
+        const path = require('path');
         this.linter && this.linter.setMessages(this.errorMatcher.getMatches().map(match => ({
           type: 'Error',
           text: match.message || 'Error from build',
-          filePath: match.file,
+          filePath: path.isAbsolute(match.file) ? match.file : path.join(cwd, match.file),
           range: [
             [ (match.line || 1) - 1, (match.col || 1) - 1 ],
             [ (match.line || 1) - 1, (match.col || 1) - 1]

--- a/lib/build.js
+++ b/lib/build.js
@@ -307,7 +307,7 @@ export default {
           filePath: path.isAbsolute(match.file) ? match.file : path.join(cwd, match.file),
           range: [
             [ (match.line || 1) - 1, (match.col || 1) - 1 ],
-            [ (match.line || 1) - 1, (match.col || 1) - 1]
+            [ (match.line_end || match.line || 1) - 1, (match.col_end || match.col || 1) - 1 ]
           ]
         })));
 

--- a/spec/linter-intergration-spec.js
+++ b/spec/linter-intergration-spec.js
@@ -9,6 +9,7 @@ describe('Linter Integration', () => {
   let directory = null;
   let workspaceElement = null;
   let dummyPackage = null;
+  const join = require('path').join;
 
   temp.track();
 
@@ -34,7 +35,7 @@ describe('Linter Integration', () => {
     waitsForPromise(() => {
       return Promise.resolve()
         .then(() => atom.packages.activatePackage('build'))
-        .then(() => atom.packages.activatePackage(`${__dirname}/fixture/atom-build-spec-linter/`))
+        .then(() => atom.packages.activatePackage(join(__dirname, 'fixture', 'atom-build-spec-linter')))
         .then(() => (dummyPackage = atom.packages.getActivePackage('atom-build-spec-linter').mainModule));
     });
   });
@@ -46,7 +47,7 @@ describe('Linter Integration', () => {
   describe('when error matching and linter is activated', () => {
     it('should push those errors to the linter', () => {
       expect(dummyPackage.hasRegistered()).toEqual(true);
-      fs.writeFileSync(`${directory}/.atom-build.json`, fs.readFileSync(`${__dirname}/fixture/.atom-build.error-match-multiple.json`));
+      fs.writeFileSync(join(directory, '.atom-build.json'), fs.readFileSync(join(__dirname, 'fixture', '.atom-build.error-match-multiple.json')));
 
       waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
@@ -61,13 +62,13 @@ describe('Linter Integration', () => {
         const linter = dummyPackage.getLinter();
         expect(linter.messages).toEqual([
           {
-            filePath: `${directory}/.atom-build.json`,
+            filePath: join(directory, '.atom-build.json'),
             range: [ [2, 7], [2, 7] ],
             text: 'Error from build',
             type: 'Error'
           },
           {
-            filePath: `${directory}/.atom-build.json`,
+            filePath: join(directory, '.atom-build.json'),
             range: [ [1, 4], [1, 4] ],
             text: 'Error from build',
             type: 'Error'
@@ -78,7 +79,7 @@ describe('Linter Integration', () => {
 
     it('should parse `message` and include that to linter', () => {
       expect(dummyPackage.hasRegistered()).toEqual(true);
-      fs.writeFileSync(`${directory}/.atom-build.json`, fs.readFileSync(`${__dirname}/fixture/.atom-build.error-match.message.json`));
+      fs.writeFileSync(join(directory, '.atom-build.json'), fs.readFileSync(join(__dirname, 'fixture', '.atom-build.error-match.message.json')));
 
       waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
@@ -93,7 +94,7 @@ describe('Linter Integration', () => {
         const linter = dummyPackage.getLinter();
         expect(linter.messages).toEqual([
           {
-            filePath: `${directory}/.atom-build.json`,
+            filePath: join(directory, '.atom-build.json'),
             range: [ [2, 7], [2, 7] ],
             text: 'very bad things',
             type: 'Error'
@@ -104,7 +105,7 @@ describe('Linter Integration', () => {
 
     it('should clear linter errors when starting a new build', () => {
       expect(dummyPackage.hasRegistered()).toEqual(true);
-      fs.writeFileSync(`${directory}/.atom-build.json`, fs.readFileSync(`${__dirname}/fixture/.atom-build.error-match.message.json`));
+      fs.writeFileSync(join(directory, '.atom-build.json'), fs.readFileSync(join(__dirname, 'fixture', '.atom-build.error-match.message.json')));
 
       waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
@@ -119,13 +120,13 @@ describe('Linter Integration', () => {
         const linter = dummyPackage.getLinter();
         expect(linter.messages).toEqual([
           {
-            filePath: `${directory}/.atom-build.json`,
+            filePath: join(directory, '.atom-build.json'),
             range: [ [2, 7], [2, 7] ],
             text: 'very bad things',
             type: 'Error'
           }
         ]);
-        fs.writeFileSync(`${directory}/.atom-build.json`, JSON.stringify({
+        fs.writeFileSync(join(directory, '.atom-build.json'), JSON.stringify({
           cmd: `${sleep(30)}`
         }));
       });

--- a/spec/linter-intergration-spec.js
+++ b/spec/linter-intergration-spec.js
@@ -61,13 +61,13 @@ describe('Linter Integration', () => {
         const linter = dummyPackage.getLinter();
         expect(linter.messages).toEqual([
           {
-            filePath: '.atom-build.json',
+            filePath: `${directory}/.atom-build.json`,
             range: [ [2, 7], [2, 7] ],
             text: 'Error from build',
             type: 'Error'
           },
           {
-            filePath: '.atom-build.json',
+            filePath: `${directory}/.atom-build.json`,
             range: [ [1, 4], [1, 4] ],
             text: 'Error from build',
             type: 'Error'
@@ -93,7 +93,7 @@ describe('Linter Integration', () => {
         const linter = dummyPackage.getLinter();
         expect(linter.messages).toEqual([
           {
-            filePath: '.atom-build.json',
+            filePath: `${directory}/.atom-build.json`,
             range: [ [2, 7], [2, 7] ],
             text: 'very bad things',
             type: 'Error'
@@ -119,7 +119,7 @@ describe('Linter Integration', () => {
         const linter = dummyPackage.getLinter();
         expect(linter.messages).toEqual([
           {
-            filePath: '.atom-build.json',
+            filePath: `${directory}/.atom-build.json`,
             range: [ [2, 7], [2, 7] ],
             text: 'very bad things',
             type: 'Error'


### PR DESCRIPTION
previously the lints did not show up in files if the paths were relative. Alternatively this could be changed in atom-linter directly, but I don't think that's feasible as atom-linter doesn't know about projects, but atom-build explicitly does.

fixes #359