### PR TITLE
.atom-build targets properties default to main target

### DIFF
--- a/lib/atom-build.js
+++ b/lib/atom-build.js
@@ -1,6 +1,7 @@
 'use babel';
 
 import EventEmitter from 'events';
+import _ from 'lodash';
 
 function getConfig(file) {
   const fs = require('fs');
@@ -19,8 +20,8 @@ function getConfig(file) {
   }
 }
 
-function createBuildConfig(build, name) {
-  const conf = {
+function createBuildConfig(build, name, defaultTarget) {
+  const conf = _.defaultsDeep({
     name: 'Custom: ' + name,
     exec: build.cmd,
     env: build.env,
@@ -30,7 +31,8 @@ function createBuildConfig(build, name) {
     errorMatch: build.errorMatch,
     atomCommandName: build.atomCommandName,
     keymap: build.keymap
-  };
+  }, defaultTarget);
+  console.log('createBuildConfig', build, name, defaultTarget, conf);
 
   if (typeof build.postBuild === 'function') {
     conf.postBuild = build.postBuild;
@@ -76,10 +78,12 @@ export default class CustomFile extends EventEmitter {
 
     const config = [];
     this.files.map(getConfig).forEach(build => {
+      var defaultTarget = createBuildConfig(build, build.name || 'default');
       config.push(
-        createBuildConfig(build, build.name || 'default'),
-        ...Object.keys(build.targets || {}).map(name => createBuildConfig(build.targets[name], name))
+        defaultTarget,
+        ...Object.keys(build.targets || {}).map(name => createBuildConfig(build.targets[name], name, defaultTarget))
       );
+
     });
 
     return config;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cson-parser": "^1.3.0",
     "getmac": "^1.0.7",
     "js-yaml": "^3.4.6",
+    "lodash": "^4.6.1",
     "node-uuid": "^1.4.3",
     "term.js": "git+https://github.com/jeremyramin/term.js.git#de1635fc2695e7d8165012d3b1d007d7ce60eea2",
     "tree-kill": "^1.0.0",


### PR DESCRIPTION
When using targets in a .atom-build file, it seems logical for the targets to "inherit" the main target.
This also makes thing a lot easier by preventing duplicate errorMatcher, postBuild, env,...