### PR TITLE
Use watchFile on Linux

### DIFF
--- a/lib/atom-build.js
+++ b/lib/atom-build.js
@@ -74,7 +74,11 @@ export default class CustomFile extends EventEmitter {
   settings() {
     const fs = require('fs');
     this.fileWatchers.forEach(fw => fw.close());
-    this.fileWatchers = this.files.map(file => fs.watch(file, () => this.emit('refresh')));
+    // On Linux, closing a watcher triggers a new callback, which causes an infinite loop
+    // fallback to `watchFile` here which polls instead.
+    this.fileWatchers = this.files.map(file =>
+      (require('os').platform() === 'linux' ? fs.watchFile : fs.watch)(file, () => this.emit('refresh'))
+    );
 
     const config = [];
     this.files.map(getConfig).forEach(build => {

--- a/spec/build-spec.js
+++ b/spec/build-spec.js
@@ -342,7 +342,7 @@ describe('Build', () => {
         }));
       });
 
-      waits(waitTime);
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => {
         atom.commands.dispatch(workspaceElement, 'build:trigger');

--- a/spec/build-visible-spec.js
+++ b/spec/build-visible-spec.js
@@ -113,7 +113,7 @@ describe('Visible', () => {
         });
 
         // .atom-build.json is updated asynchronously... give it some time
-        waits(waitTime);
+        waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
         runs(() => {
           atom.commands.dispatch(workspaceElement, 'build:trigger');


### PR DESCRIPTION
On linux, watch can not be used since closing the watcher triggers
a callback in the new watcher which ends up being an infinite loop.

Fixes #277