### PR TITLE
Added /opt/local/bin as a possible path extension.

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -9,6 +9,10 @@ export default {
       // and it's common to have node installed here. Keep it at end so it won't
       // accidentially override any other node installation
       process.env.PATH += ':/usr/local/bin';
+      
+      // Some systems have binaries installed here (Through MacPorts for example)
+      process.env.PATH += ':/opt/local/bin';
+
     }
 
     this.instancedTools = {}; // Ordered by project path


### PR DESCRIPTION
Hi!

On my OSX machine, the command-line version of cmake was installed in "/opt/local/bin", which your package couldn't find.

This change fixes that.