### PR TITLE
Issue with 'Panel Orientation' Left or Right

### DIFF
--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -71,7 +71,6 @@ export default class BuildView extends View {
     atom.config.observe('editor.fontSize', ::this.fontSizeFromConfig);
     atom.config.observe('editor.fontFamily', ::this.fontFamilyFromConfig);
     atom.commands.add('atom-workspace', 'build:toggle-panel', ::this.toggle);
-
     this.cache = { Left: {}, Right: {}, Top: {}, Bottom: {} };
   }
 
@@ -165,9 +164,9 @@ export default class BuildView extends View {
       return;
     }
     const orientation = atom.config.get('build.panelOrientation') || 'Bottom';
-    if(orientation === "Left" || orientation === "Right")
+    if(orientation === 'Left' || orientation === 'Right')
       this.cache[orientation].width = $('.build .output').width();
-    if(orientation === "Top" || orientation === "Bottom")
+    else if(orientation === 'Top' || orientation === 'Bottom')
       this.cache[orientation].height = $('.build .output').height();
     this.terminalEl.css('height', `${this.cache[orientation].height}px`);
     this.terminalEl.css('width', `${this.cache[orientation].width}px`);
@@ -175,9 +174,11 @@ export default class BuildView extends View {
     const terminalHeight = Math.floor((this.terminalEl.height()) / h);
     this.terminal.resize(terminalWidth, terminalHeight);
   }
+
   getContent() {
     return this.terminal.getContent();
   }
+
   attach(force = false) {
     if (!force) {
       switch (atom.config.get('build.panelVisibility')) {
@@ -197,17 +198,16 @@ export default class BuildView extends View {
     };
     const orientation = atom.config.get('build.panelOrientation') || 'Bottom';
     this.panel = addfn[orientation].call(atom.workspace, { item: this });
-    if(orientation === "Left" || orientation === "Right")
+    if(orientation === 'Left' || orientation === 'Right')
     {
       this.cache[orientation].height = $('.item-views').height();
       this.cache[orientation].width = this.cache[orientation].width || 250;
     }
-    if(orientation === "Top" || orientation === "Bottom")
+    else if(orientation === 'Top' || orientation === 'Bottom')
     {
       this.cache[orientation].width = $('.item-views').width();
       this.cache[orientation].height = this.cache[orientation].height || 250;
     }
-    console.log("attach()", this.cache[orientation].width, this.cache[orientation].height);
     this.resizeToNearestRow();
   }
 

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -138,7 +138,6 @@ export default class BuildView extends View {
       return;
     }
     const orientation = atom.config.get('build.panelOrientation') || 'Bottom';
-    var width = this.cache[orientation].width;
     var height = this.cache[orientation].height;
     const { h } = this.getFontGeometry();
     const nearestRowHeight = Math.round(height / h) * h;
@@ -164,10 +163,11 @@ export default class BuildView extends View {
       return;
     }
     const orientation = atom.config.get('build.panelOrientation') || 'Bottom';
-    if(orientation === 'Left' || orientation === 'Right')
+    if(orientation === 'Left' || orientation === 'Right') {
       this.cache[orientation].width = $('.build .output').width();
-    else if(orientation === 'Top' || orientation === 'Bottom')
+    } else if(orientation === 'Top' || orientation === 'Bottom') {
       this.cache[orientation].height = $('.build .output').height();
+    }
     this.terminalEl.css('height', `${this.cache[orientation].height}px`);
     this.terminalEl.css('width', `${this.cache[orientation].width}px`);
     const terminalWidth = Math.floor((this.terminalEl.width()) / w);
@@ -198,13 +198,11 @@ export default class BuildView extends View {
     };
     const orientation = atom.config.get('build.panelOrientation') || 'Bottom';
     this.panel = addfn[orientation].call(atom.workspace, { item: this });
-    if(orientation === 'Left' || orientation === 'Right')
-    {
+    if(orientation === 'Left' || orientation === 'Right') {
+      $('.build .output').width()
       this.cache[orientation].height = $('.item-views').height();
       this.cache[orientation].width = this.cache[orientation].width || 250;
-    }
-    else if(orientation === 'Top' || orientation === 'Bottom')
-    {
+    } else if(orientation === 'Top' || orientation === 'Bottom') {
       this.cache[orientation].width = $('.item-views').width();
       this.cache[orientation].height = this.cache[orientation].height || 250;
     }

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -71,6 +71,8 @@ export default class BuildView extends View {
     atom.config.observe('editor.fontSize', ::this.fontSizeFromConfig);
     atom.config.observe('editor.fontFamily', ::this.fontFamilyFromConfig);
     atom.commands.add('atom-workspace', 'build:toggle-panel', ::this.toggle);
+
+    this.cache = { Left: {}, Right: {}, Top: {}, Bottom: {} };
   }
 
   destroy() {
@@ -131,12 +133,16 @@ export default class BuildView extends View {
   }
 
   resizeToNearestRow() {
+    if(typeof this.cache === 'undefined') return;
     if (-1 !== [ 'Left', 'Right' ].indexOf(atom.config.get('build.panelOrientation'))) {
       this.resizeTerminal();
       return;
     }
+    const orientation = atom.config.get('build.panelOrientation') || 'Bottom';
+    var width = this.cache[orientation].width;
+    var height = this.cache[orientation].height;
     const { h } = this.getFontGeometry();
-    const nearestRowHeight = Math.round(this.terminalEl.height() / h) * h;
+    const nearestRowHeight = Math.round(height / h) * h;
     this.terminalEl.css('height', `${nearestRowHeight}px`);
     this.resizeTerminal();
   }
@@ -158,17 +164,20 @@ export default class BuildView extends View {
     if (0 === w || 0 === h) {
       return;
     }
-
+    const orientation = atom.config.get('build.panelOrientation') || 'Bottom';
+    if(orientation === "Left" || orientation === "Right")
+      this.cache[orientation].width = $('.build .output').width();
+    if(orientation === "Top" || orientation === "Bottom")
+      this.cache[orientation].height = $('.build .output').height();
+    this.terminalEl.css('height', `${this.cache[orientation].height}px`);
+    this.terminalEl.css('width', `${this.cache[orientation].width}px`);
     const terminalWidth = Math.floor((this.terminalEl.width()) / w);
     const terminalHeight = Math.floor((this.terminalEl.height()) / h);
-
     this.terminal.resize(terminalWidth, terminalHeight);
   }
-
   getContent() {
     return this.terminal.getContent();
   }
-
   attach(force = false) {
     if (!force) {
       switch (atom.config.get('build.panelVisibility')) {
@@ -177,11 +186,9 @@ export default class BuildView extends View {
           return;
       }
     }
-
     if (this.panel) {
       this.panel.destroy();
     }
-
     const addfn = {
       Top: atom.workspace.addTopPanel,
       Bottom: atom.workspace.addBottomPanel,
@@ -190,6 +197,17 @@ export default class BuildView extends View {
     };
     const orientation = atom.config.get('build.panelOrientation') || 'Bottom';
     this.panel = addfn[orientation].call(atom.workspace, { item: this });
+    if(orientation === "Left" || orientation === "Right")
+    {
+      this.cache[orientation].height = $('.item-views').height();
+      this.cache[orientation].width = this.cache[orientation].width || 250;
+    }
+    if(orientation === "Top" || orientation === "Bottom")
+    {
+      this.cache[orientation].width = $('.item-views').width();
+      this.cache[orientation].height = this.cache[orientation].height || 250;
+    }
+    console.log("attach()", this.cache[orientation].width, this.cache[orientation].height);
     this.resizeToNearestRow();
   }
 


### PR DESCRIPTION
Hi. Firstly, thanks for atom-build!

I have recently stared using the left and right orientations and noticed an issue with the terminal window not filling the full height of the container. I have tried to fix this and also added a non persistent  cache for the width/height values so that they are maintained between switching orientation.

Thanks