### PR TITLE
added option to refresh targets on demand

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -185,7 +185,7 @@ export default {
   },
 
   selectActiveTarget() {
-    if (atom.config.get('build.refreshTargetsOnDemand')) {
+    if (atom.config.get('build.refreshOnShowTargetList')) {
       this.refreshTargets();
     }
     const p = require('./utils').activePath();

--- a/lib/build.js
+++ b/lib/build.js
@@ -186,7 +186,7 @@ export default {
 
   selectActiveTarget() {
     if (atom.config.get('build.refreshTargetsOnDemand')) {
-        this.refreshTargets();
+      this.refreshTargets();
     }
     const p = require('./utils').activePath();
     const TargetsView = require('./targets-view');

--- a/lib/build.js
+++ b/lib/build.js
@@ -185,6 +185,9 @@ export default {
   },
 
   selectActiveTarget() {
+    if (atom.config.get('build.refreshTargetsOnDemand')) {
+        this.refreshTargets();
+    }
     const p = require('./utils').activePath();
     const TargetsView = require('./targets-view');
     this.targetsView = new TargetsView();

--- a/lib/config.js
+++ b/lib/config.js
@@ -65,7 +65,6 @@ export default {
     default: true,
     order: 9
   },
-
   refreshTargetsOnDemand: {
     title: 'Refresh targets on demand',
     description: 'When opening the targets menu, the targets will be refreshed.',

--- a/lib/config.js
+++ b/lib/config.js
@@ -65,19 +65,27 @@ export default {
     default: true,
     order: 9
   },
+
+  refreshTargetsOnDemand: {
+    title: 'Refresh targets on demand',
+    description: 'When opening the targets menu, the targets will be refreshed.',
+    type: 'boolean',
+    default: false,
+    order: 10
+  },
   notificationOnRefresh: {
     title: 'Show notification when targets are refreshed',
     description: 'When targets are refreshed a notification with information about the number of targets will be displayed.',
     type: 'boolean',
     default: false,
-    order: 10
+    order: 11
   },
   beepWhenDone: {
     title: 'Beep when the build completes',
     description: 'Make a "beep" notification sound when the build is complete - in success or failure.',
     type: 'boolean',
     default: false,
-    order: 11
+    order: 12
   },
   panelOrientation: {
     title: 'Panel Orientation',
@@ -85,7 +93,7 @@ export default {
     type: 'string',
     default: 'Bottom',
     enum: [ 'Bottom', 'Top', 'Left', 'Right' ],
-    order: 12
+    order: 13
   },
   statusBar: {
     title: 'Status Bar',
@@ -93,13 +101,13 @@ export default {
     type: 'string',
     default: 'Left',
     enum: [ 'Left', 'Right', 'Disable' ],
-    order: 13
+    order: 14
   },
   statusBarPriority: {
     title: 'Priority on Status Bar',
     description: 'Lower priority tiles are placed further to the left/right, depends on where you choose to place Status Bar.',
     type: 'number',
     default: -1000,
-    order: 14
+    order: 15
   }
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -65,8 +65,8 @@ export default {
     default: true,
     order: 9
   },
-  refreshTargetsOnDemand: {
-    title: 'Refresh targets on demand',
+  refreshOnShowTargetList: {
+    title: 'Refresh targets when the target list is shown',
     description: 'When opening the targets menu, the targets will be refreshed.',
     type: 'boolean',
     default: false,


### PR DESCRIPTION
Hi,
I need this for a build provider which depends on the currently selected file.
This is due to the fact, that I usually don't add each (latex) project path to atom, but one path with subprojects.
If this gets merged, I could also publish my small provider.