### PR TITLE
Error matcher tweak

### DIFF
--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -75,6 +75,8 @@ export default class ErrorMatcher extends EventEmitter {
         if (!match.file) {
           match.file = atom.workspace.getActivePaneItem().buffer.file.path;
         }
+      } catch {
+        console.log("build: Target provider did not give a 'file' and there is no valid open file!");
       } finally {
         // if no (real) file was open in the editor, match.file remains empty
         this.push(match);

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -71,6 +71,10 @@ export default class ErrorMatcher extends EventEmitter {
     const self = this;
     const matchFunction = function (match, i, string, regex) {
       match.id = 'error-match-' + self.regex.indexOf(regex) + '-' + i;
+      if (!match.file) {
+        try {match.file = atom.workspace.getActivePaneItem().buffer.file.path}
+        catch(err) {} // no file opened in editor -> really no file available
+      }
       this.push(match);
     };
     this.regex.forEach((regex) => {

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -71,16 +71,15 @@ export default class ErrorMatcher extends EventEmitter {
     const self = this;
     const matchFunction = function (match, i, string, regex) {
       match.id = 'error-match-' + self.regex.indexOf(regex) + '-' + i;
-      try {
-        if (!match.file) {
+      if (!match.file) {
+        try {
           match.file = atom.workspace.getActivePaneItem().buffer.file.path;
+        } catch (err) {
+          // console.log("build error log parse error: Target provider did not match a 'file' and there is no valid open file!");
         }
-      } catch {
-        console.log("build: Target provider did not give a 'file' and there is no valid open file!");
-      } finally {
-        // if no (real) file was open in the editor, match.file remains empty
-        this.push(match);
       }
+      // if no (real) file was open in the editor, match.file remains empty
+      this.push(match);
     };
     this.regex.forEach((regex) => {
       require('xregexp').forEach(this.output, regex, matchFunction.bind(this.currentMatch));

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -74,8 +74,8 @@ export default class ErrorMatcher extends EventEmitter {
       try {
         if (!match.file) {
           match.file = atom.workspace.getActivePaneItem().buffer.file.path;
-      }}
-      finally {
+        }
+      } finally {
         // if no (real) file was open in the editor, match.file remains empty
         this.push(match);
       }

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -74,8 +74,7 @@ export default class ErrorMatcher extends EventEmitter {
       try {
         if (!match.file) {
           match.file = atom.workspace.getActivePaneItem().buffer.file.path;
-        }
-      }
+      }}
       finally {
         // if no (real) file was open in the editor, match.file remains empty
         this.push(match);

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -71,11 +71,15 @@ export default class ErrorMatcher extends EventEmitter {
     const self = this;
     const matchFunction = function (match, i, string, regex) {
       match.id = 'error-match-' + self.regex.indexOf(regex) + '-' + i;
-      if (!match.file) {
-        try {match.file = atom.workspace.getActivePaneItem().buffer.file.path}
-        catch(err) {} // no file opened in editor -> really no file available
+      try {
+        if (!match.file) {
+          match.file = atom.workspace.getActivePaneItem().buffer.file.path;
+        }
       }
-      this.push(match);
+      finally {
+        // if no (real) file was open in the editor, match.file remains empty
+        this.push(match);
+      }
     };
     this.regex.forEach((regex) => {
       require('xregexp').forEach(this.output, regex, matchFunction.bind(this.currentMatch));


### PR DESCRIPTION
Hi, i'ts me again with my file-based target provider :)
I wanted to match errors in LaTeX targets, where there is the problem that the build logs don't contain the file name. My solution is to use the current file, if the match pattern did not contain a (?\<file\> RE ) named group.
If a target provider implements the file group, nothing changes. Only if it does not, build tries to get the current file and uses it as reference.
Maybe one could add an option for this, but in my opinion this is nothing the user should bother with.

Regards,
Tasnad