### PR TITLE
Allow to install package without GIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "getmac": "^1.0.7",
     "js-yaml": "^3.4.6",
     "node-uuid": "^1.4.3",
-    "term.js": "git+https://github.com/jeremyramin/term.js.git#de1635fc2695e7d8165012d3b1d007d7ce60eea2",
+    "term.js": "https://github.com/jeremyramin/term.js/tarball/de1635fc2695e7d8165012d3b1d007d7ce60eea2",
     "tree-kill": "^1.0.0",
     "xregexp": "^3.1.0"
   },


### PR DESCRIPTION
If git is not installed in the system (and it is OK), user will receive
```
Installing “build@0.59.0” failed.Hide output…
Failed to install build because Git was not found.

The build package has module dependencies that cannot be installed without Git.

You need to install Git and add it to your path environment variable in order to install this package.

You can install Git by downloading, installing, and launching GitHub for Windows: https://windows.github.com

Run apm -v after installing Git to see what version has been detected.
```

Please release 0.59.1. Thanks.