### PR TITLE
Avoid exception when selecting targets outside of project

### DIFF
--- a/lib/target-manager.js
+++ b/lib/target-manager.js
@@ -167,7 +167,15 @@ class TargetManager extends EventEmitter {
     if (atom.config.get('build.refreshOnShowTargetList')) {
       this.refreshTargets();
     }
+
     const path = require('./utils').activePath();
+    if (!path) {
+      atom.notifications.addWarning('Unable to build.', {
+        detail: 'Open file is not part of any open project in Atom'
+      });
+      return;
+    }
+
     const TargetsView = require('./targets-view');
     this.targetsView = new TargetsView();
 

--- a/spec/build-spec.js
+++ b/spec/build-spec.js
@@ -301,11 +301,11 @@ describe('Build', () => {
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
-        return atom.notifications.getNotifications().length > 0;
+        return atom.notifications.getNotifications().find(n => n.getType() === 'error');
       });
 
       runs(() => {
-        const notification = atom.notifications.getNotifications()[0];
+        const notification = atom.notifications.getNotifications().find(n => n.getType() === 'error');
         expect(notification.getType()).toEqual('error');
         expect(notification.getMessage()).toEqual('Invalid build file.');
         expect(notification.options.detail).toMatch(/Unexpected token t/);

--- a/spec/build-targets-spec.js
+++ b/spec/build-targets-spec.js
@@ -2,6 +2,7 @@
 
 import fs from 'fs-extra';
 import temp from 'temp';
+import path from 'path';
 import specHelpers from 'atom-build-spec-helpers';
 import os from 'os';
 
@@ -198,7 +199,7 @@ describe('Target', () => {
     });
 
     it('should show a warning if current file is not part of an open Atom project', () => {
-      waitsForPromise(() => atom.workspace.open('/randomFile'));
+      waitsForPromise(() => atom.workspace.open(path.join('..', 'randomFile')));
       waitsForPromise(() => specHelpers.refreshAwaitTargets());
       runs(() => atom.commands.dispatch(workspaceElement, 'build:select-active-target'));
       waitsFor(() => atom.notifications.getNotifications().find(n => n.message === 'Unable to build.'));

--- a/spec/build-targets-spec.js
+++ b/spec/build-targets-spec.js
@@ -196,5 +196,16 @@ describe('Target', () => {
         expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/customized/);
       });
     });
+
+    it('should show a warning if current file is not part of an open Atom project', () => {
+      waitsForPromise(() => atom.workspace.open('/randomFile'));
+      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:select-active-target'));
+      waitsFor(() => atom.notifications.getNotifications().find(n => n.message === 'Unable to build.'));
+      runs(() => {
+        const not = atom.notifications.getNotifications().find(n => n.message === 'Unable to build.');
+        expect(not.type).toBe('warning');
+      });
+    });
   });
 });


### PR DESCRIPTION
If selecting targets when a file which is not part of an open
project in Atom is open, it should gracefully let the user know
that this is the case via a notification.

Fixes #403