### PR TITLE
Refresh the target list when without targets

### DIFF
--- a/lib/target-manager.js
+++ b/lib/target-manager.js
@@ -123,7 +123,7 @@ class TargetManager extends EventEmitter {
       });
     });
 
-    Promise.all(pathPromises).then(entries => {
+    return Promise.all(pathPromises).then(entries => {
       this.fillTargets(require('./utils').activePath());
       this.emit('refresh-complete');
 
@@ -193,6 +193,9 @@ class TargetManager extends EventEmitter {
       return [];
     }
 
+    if (pathTarget.targets.length === 0) {
+      return this.refreshTargets([ pathTarget.path ]).then(() => pathTarget.targets);
+    }
     return pathTarget.targets;
   }
 

--- a/spec/build-confirm-spec.js
+++ b/spec/build-confirm-spec.js
@@ -2,7 +2,6 @@
 
 import fs from 'fs-extra';
 import temp from 'temp';
-import specHelpers from 'atom-build-spec-helpers';
 import os from 'os';
 
 describe('Confirm', () => {
@@ -110,7 +109,6 @@ describe('Confirm', () => {
 
       waitsForPromise(() => {
         return Promise.all([
-          specHelpers.refreshAwaitTargets(),
           atom.workspace.open('.atom-build.json'),
           atom.workspace.open()
         ]);
@@ -143,12 +141,7 @@ describe('Confirm', () => {
         cmd: `${cat} catme`
       }));
 
-      waitsForPromise(() => {
-        return Promise.all([
-          specHelpers.refreshAwaitTargets(),
-          atom.workspace.open('catme')
-        ]);
-      });
+      waitsForPromise(() => atom.workspace.open('catme'));
 
       runs(() => {
         const editor = atom.workspace.getActiveTextEditor();
@@ -180,12 +173,7 @@ describe('Confirm', () => {
         cmd: `${cat} catme`
       }));
 
-      waitsForPromise(() => {
-        return Promise.all([
-          specHelpers.refreshAwaitTargets(),
-          atom.workspace.open('catme')
-        ]);
-      });
+      waitsForPromise(() => atom.workspace.open('catme'));
 
       runs(() => {
         const editor = atom.workspace.getActiveTextEditor();
@@ -220,12 +208,7 @@ describe('Confirm', () => {
         cmd: `${cat} catme`
       }));
 
-      waitsForPromise(() => {
-        return Promise.all([
-          specHelpers.refreshAwaitTargets(),
-          atom.workspace.open('catme')
-        ]);
-      });
+      waitsForPromise(() => atom.workspace.open('catme'));
 
       runs(() => {
         const editor = atom.workspace.getActiveTextEditor();
@@ -257,12 +240,7 @@ describe('Confirm', () => {
         cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
       }));
 
-      waitsForPromise(() => {
-        return Promise.all([
-          specHelpers.refreshAwaitTargets(),
-          atom.workspace.open('.atom-build.json')
-        ]);
-      });
+      waitsForPromise(() => atom.workspace.open('.atom-build.json'));
 
       runs(() => {
         const editor = atom.workspace.getActiveTextEditor();

--- a/spec/build-error-match-spec.js
+++ b/spec/build-error-match-spec.js
@@ -3,7 +3,6 @@
 import fs from 'fs-extra';
 import path from 'path';
 import temp from 'temp';
-import specHelpers from 'atom-build-spec-helpers';
 import os from 'os';
 
 describe('Error Match', () => {
@@ -62,8 +61,6 @@ describe('Error Match', () => {
         errorMatch: '(invalidRegex'
       }));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -85,8 +82,6 @@ describe('Error Match', () => {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchAtomBuildFile));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
@@ -117,8 +112,6 @@ describe('Error Match', () => {
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchNoFileBuildFile));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -145,8 +138,6 @@ describe('Error Match', () => {
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchNLCAtomBuildFile));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -172,8 +163,6 @@ describe('Error Match', () => {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchMultiAtomBuildFile));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
@@ -237,8 +226,6 @@ describe('Error Match', () => {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchMultiFirstAtomBuildFile));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
@@ -304,8 +291,6 @@ describe('Error Match', () => {
         errorMatch: '__(?<file>.+)__'
       }));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -334,8 +319,6 @@ describe('Error Match', () => {
         errorMatch: '__(?<file>.+)__'
       };
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify(atomBuild));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
@@ -380,8 +363,6 @@ describe('Error Match', () => {
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchAtomBuildFile));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -405,8 +386,6 @@ describe('Error Match', () => {
     it('should scroll the build panel to the text of the error', () => {
       expect(workspaceElement.querySelector('.build')).not.toExist();
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchLongOutputAtomBuildFile));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
@@ -442,8 +421,6 @@ describe('Error Match', () => {
       expect(workspaceElement.querySelector('.build')).not.toExist();
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchLongOutputAtomBuildFile));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -477,8 +454,6 @@ describe('Error Match', () => {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(errorMatchMultiMatcherAtomBuildFile));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 

--- a/spec/build-keymap-spec.js
+++ b/spec/build-keymap-spec.js
@@ -56,8 +56,6 @@ describe('Keymap', () => {
         }
       }));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -99,8 +97,6 @@ describe('Keymap', () => {
           }
         }
       }));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
@@ -162,8 +158,6 @@ describe('Keymap', () => {
           }
         }
       }));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 

--- a/spec/build-spec.js
+++ b/spec/build-spec.js
@@ -71,8 +71,6 @@ describe('Build', () => {
         cmd: 'echo Very bad... && exit 1'
       }));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -94,8 +92,6 @@ describe('Build', () => {
         errorMatch: 'ERROR'
       }));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -110,8 +106,6 @@ describe('Build', () => {
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
         cmd: `echo "Building, this will take some time..." && ${sleep(30)} && echo "Done!"`
       }));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
@@ -150,6 +144,24 @@ describe('Build', () => {
         expect(workspaceElement.querySelector('.build')).not.toExist();
       });
     });
+
+    it('should automatically refresh if build is triggered an no targets are found', () => {
+      expect(workspaceElement.querySelector('.build')).not.toExist();
+
+      fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
+        cmd: 'echo hello world'
+      }));
+
+      atom.commands.dispatch(workspaceElement, 'build:trigger');
+
+      waitsFor(() =>
+        workspaceElement.querySelector('.build .title') &&
+        workspaceElement.querySelector('.build .title').classList.contains('success'));
+
+      runs(() => {
+        expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/hello world/);
+      });
+    });
   });
 
   describe('when build is triggered twice', () => {
@@ -161,8 +173,6 @@ describe('Build', () => {
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
         cmd: 'echo hello world'
       }));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
@@ -194,8 +204,6 @@ describe('Build', () => {
         args: [ '.atom-build.json' ]
       }));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -214,8 +222,6 @@ describe('Build', () => {
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(shellAtomBuildfile));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -233,8 +239,6 @@ describe('Build', () => {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(shTrueAtomBuildFile));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
@@ -256,8 +260,6 @@ describe('Build', () => {
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(shFalseAtomBuildFile));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -276,8 +278,6 @@ describe('Build', () => {
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(shDefaultAtomBuildFile));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -295,8 +295,6 @@ describe('Build', () => {
       expect(workspaceElement.querySelector('.build')).not.toExist();
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(syntaxErrorAtomBuildFile));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
@@ -319,9 +317,7 @@ describe('Build', () => {
         cmd: 'echo first'
       }));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
-      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+      atom.commands.dispatch(workspaceElement, 'build:trigger');
 
       waitsFor(() => {
         return workspaceElement.querySelector('.build .title') &&
@@ -344,9 +340,7 @@ describe('Build', () => {
 
       waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
-      runs(() => {
-        atom.commands.dispatch(workspaceElement, 'build:trigger');
-      });
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
         return workspaceElement.querySelector('.build .title') &&
@@ -366,12 +360,7 @@ describe('Build', () => {
       process.env.FROM_PROCESS_ENV = '{FILE_ACTIVE}';
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(replaceAtomBuildFile));
 
-      waitsForPromise(() => {
-        return Promise.all([
-          specHelpers.refreshAwaitTargets(),
-          atom.workspace.open('.atom-build.json')
-        ]);
-      });
+      waitsForPromise(() => atom.workspace.open('.atom-build.json'));
 
       runs(() => atom.workspace.getActiveTextEditor().setSelectedBufferRange([[1, 3], [1, 6]]));
 
@@ -404,12 +393,7 @@ describe('Build', () => {
         cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
       }));
 
-      waitsForPromise(() => {
-        return Promise.all([
-          specHelpers.refreshAwaitTargets(),
-          atom.workspace.open('dummy')
-        ]);
-      });
+      waitsForPromise(() => atom.workspace.open('dummy'));
 
       runs(() => {
         const editor = atom.workspace.getActiveTextEditor();
@@ -434,12 +418,7 @@ describe('Build', () => {
         cmd: 'echo "hello, world"'
       });
 
-      waitsForPromise(() => {
-        return Promise.all([
-          specHelpers.refreshAwaitTargets(),
-          atom.workspace.open('dummy')
-        ]);
-      });
+      waitsForPromise(() => atom.workspace.open('dummy'));
 
       runs(() => {
         const editor = atom.workspace.getActiveTextEditor();
@@ -454,7 +433,9 @@ describe('Build', () => {
     it('should not attempt to build if buildOnSave is true and no build tool exists', () => {
       atom.config.set('build.buildOnSave', true);
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
+      fs.writeFileSync(directory + '.atom-build.json', {
+        cmd: 'echo "hello, world"'
+      });
 
       waitsForPromise(() => {
         return atom.workspace.open('dummy');
@@ -483,12 +464,7 @@ describe('Build', () => {
         args: [ '.atom-build.json' ]
       }));
 
-      waitsForPromise(() => {
-        return Promise.all([
-          specHelpers.refreshAwaitTargets(),
-          atom.workspace.open(directory2 + '/main.c')
-        ]);
-      });
+      waitsForPromise(() => atom.workspace.open(directory2 + '/main.c'));
 
       runs(() => {
         atom.workspace.getActiveTextEditor().save();
@@ -554,8 +530,6 @@ describe('Build', () => {
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(goodAtomBuildfile));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -574,8 +548,6 @@ describe('Build', () => {
       const activeElement = document.activeElement;
 
       fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(goodAtomBuildfile));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 

--- a/spec/build-targets-spec.js
+++ b/spec/build-targets-spec.js
@@ -17,6 +17,7 @@ describe('Target', () => {
     atom.config.set('build.panelVisibility', 'Toggle');
     atom.config.set('build.saveOnBuild', false);
     atom.config.set('build.notificationOnRefresh', true);
+    atom.config.set('build.refreshOnShowTargetList', true);
 
     jasmine.unspy(window, 'setTimeout');
     jasmine.unspy(window, 'clearTimeout');
@@ -50,11 +51,8 @@ describe('Target', () => {
     it('should list those targets in a SelectListView (from .atom-build.json)', () => {
       waitsForPromise(() => {
         const file = __dirname + '/fixture/.atom-build.targets.json';
-        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json')
-          .then(() => specHelpers.refreshAwaitTargets());
+        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json');
       });
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => {
         atom.commands.dispatch(workspaceElement, 'build:select-active-target');
@@ -73,8 +71,7 @@ describe('Target', () => {
     it('should mark the first target as active', () => {
       waitsForPromise(() => {
         const file = __dirname + '/fixture/.atom-build.targets.json';
-        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json')
-          .then(() => specHelpers.refreshAwaitTargets());
+        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json');
       });
 
       runs(() => {
@@ -95,8 +92,7 @@ describe('Target', () => {
     it('should run the selected build', () => {
       waitsForPromise(() => {
         const file = __dirname + '/fixture/.atom-build.targets.json';
-        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json')
-          .then(() => specHelpers.refreshAwaitTargets());
+        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json');
       });
 
       runs(() => {
@@ -124,8 +120,7 @@ describe('Target', () => {
     it('should run the default target if no selection has been made', () => {
       waitsForPromise(() => {
         const file = __dirname + '/fixture/.atom-build.targets.json';
-        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json')
-          .then(() => specHelpers.refreshAwaitTargets());
+        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json');
       });
 
       runs(() => {
@@ -145,8 +140,7 @@ describe('Target', () => {
     it('run the selected target if selection has changed, and subsequent build should run that target', () => {
       waitsForPromise(() => {
         const file = __dirname + '/fixture/.atom-build.targets.json';
-        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json')
-          .then(() => specHelpers.refreshAwaitTargets());
+        return specHelpers.vouch(fs.copy, file, directory + '/.atom-build.json');
       });
 
       runs(() => {

--- a/spec/build-view-spec.js
+++ b/spec/build-view-spec.js
@@ -62,8 +62,6 @@ describe('BuildView', () => {
         sh: false
       }));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -82,8 +80,6 @@ describe('BuildView', () => {
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
         cmd: 'echo "<tag>"'
       }));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
@@ -106,8 +102,6 @@ describe('BuildView', () => {
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
         cmd: `echo "Building, this will take some time..." && ${sleep(30)} && echo "Done!"`
       }));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
@@ -134,8 +128,6 @@ describe('BuildView', () => {
         cmd: 'echo this will fail && exit 1'
       }));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -157,8 +149,6 @@ describe('BuildView', () => {
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
         cmd: 'echo this will fail && exit 1'
       }));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
@@ -182,8 +172,6 @@ describe('BuildView', () => {
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
         cmd: 'echo a && echo b && echo c && echo d && echo e && echo f && echo g && echo h && exit 1'
       }));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
@@ -214,8 +202,6 @@ describe('BuildView', () => {
         cmd: 'echo hello && exit 1'
       }));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -233,8 +219,6 @@ describe('BuildView', () => {
       fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
         cmd: 'echo hello && exit 1'
       }));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 

--- a/spec/build-visible-spec.js
+++ b/spec/build-visible-spec.js
@@ -95,8 +95,6 @@ describe('Visible', () => {
           cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
         }));
 
-        waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
         runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
         /* Give it some reasonable time to show itself if there is a bug */
@@ -140,8 +138,6 @@ describe('Visible', () => {
           cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
         }));
 
-        waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
         runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
         /* Give it some reasonable time to show itself if there is a bug */
@@ -159,8 +155,6 @@ describe('Visible', () => {
           cmd: 'echo "Very bad..." && exit 2'
         }));
 
-        waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
         runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
         /* Give it some reasonable time to show itself if there is a bug */
@@ -177,8 +171,6 @@ describe('Visible', () => {
         fs.writeFileSync(directory + '.atom-build.json', JSON.stringify({
           cmd: 'echo Surprising is the passing of time but not so, as the time of passing.'
         }));
-
-        waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
         runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 

--- a/spec/linter-intergration-spec.js
+++ b/spec/linter-intergration-spec.js
@@ -49,8 +49,6 @@ describe('Linter Integration', () => {
       expect(dummyPackage.hasRegistered()).toEqual(true);
       fs.writeFileSync(join(directory, '.atom-build.json'), fs.readFileSync(join(__dirname, 'fixture', '.atom-build.error-match-multiple.json')));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -81,8 +79,6 @@ describe('Linter Integration', () => {
       expect(dummyPackage.hasRegistered()).toEqual(true);
       fs.writeFileSync(join(directory, '.atom-build.json'), fs.readFileSync(join(__dirname, 'fixture', '.atom-build.error-match.message.json')));
 
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
-
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
@@ -106,8 +102,6 @@ describe('Linter Integration', () => {
     it('should clear linter errors when starting a new build', () => {
       expect(dummyPackage.hasRegistered()).toEqual(true);
       fs.writeFileSync(join(directory, '.atom-build.json'), fs.readFileSync(join(__dirname, 'fixture', '.atom-build.error-match.message.json')));
-
-      waitsForPromise(() => specHelpers.refreshAwaitTargets());
 
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 


### PR DESCRIPTION
This helps resolve the issue where someone installs
atom-build, creates a yml file and manually have to
hit refresh to get the targets in there.

Fixes #409