### PR TITLE
Error match on abort

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -236,10 +236,7 @@ export default {
   },
 
   abort(cb) {
-    this.child.removeAllListeners('exit');
-    this.child.removeAllListeners('close');
     this.child.on('exit', () => {
-      this.child.removeAllListeners();
       this.child = null;
       cb && cb();
     });


### PR DESCRIPTION
Allow error matching even if build is aborted. This can be useful
if you spot an error in the output, and the build is long running.
Really, there's no drawback to allowing it, so...

Fixes #382