### PR TITLE
Use resizer when calculatin resize

### DIFF
--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -89,7 +89,7 @@ export default class BuildView extends View {
 
     switch (atom.config.get('build.panelOrientation')) {
       case 'Bottom': {
-        const delta = this.panelHeading.get(0).getBoundingClientRect().top - ev.y;
+        const delta = this.resizer.get(0).getBoundingClientRect().top - ev.y;
         if (Math.abs(delta) < (h * 5 / 6)) return;
 
         const nearestRowHeight = Math.round((this.terminalEl.height() + delta) / h) * h;


### PR DESCRIPTION
Resizer is always available. The panel heading as reference
was just legacy from before when the resizer didn't exist
in bottom mode.

Fixes #379