### PR TITLE
normal font-weight in build output "terminal"

### DIFF
--- a/styles/build.less
+++ b/styles/build.less
@@ -71,6 +71,7 @@
       margin: 0;
       height: 100%;
       width: 100%;
+      font-weight: normal;
       > div {
         white-space: nowrap;
         font-size: inherit;


### PR DESCRIPTION
The 600 weight is fine for the panel header, but the output is much easier to read if it's at normal font-wight.

<img width="221" alt="screen shot 2016-05-04 at 10 06 18" src="https://cloud.githubusercontent.com/assets/2543659/15008330/ddf13784-11df-11e6-9585-9dea07096dc4.png">

<img width="300" alt="screen shot 2016-05-04 at 10 06 00" src="https://cloud.githubusercontent.com/assets/2543659/15008332/e06ebb6c-11df-11e6-8adf-9fb5efcf6de6.png">
