### PR TITLE
enable traces (sub/child-errors) and custom "error types"

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,25 +110,21 @@ module.exports = {
   postBuild: function () {
     console.log('This is run **after** the build command');
   },
-  errorMatch: [
-    // normal regexes and functions may be mixed in this array
-    'this is a regex',
-    function (terminal_output) {
-      // this is the array of matches that we create
-      var matches = [];
-      terminal_output.split(/\n/).forEach(function (line, line_number, terminal_output) {
-        // all lines starting with a slash
-        if line[0] == '/' {
-          this.push({
-            file: 'x.txt',
-            line: line_number.toString(),
-            message: line
-          });
-        }
-      }.bind(matches));
-      return matches;
-    }
-  ]
+  functionMatch: function (terminal_output) {
+    // this is the array of matches that we create
+    var matches = [];
+    terminal_output.split(/\n/).forEach(function (line, line_number, terminal_output) {
+      // all lines starting with a slash
+      if line[0] == '/' {
+        this.push({
+          file: 'x.txt',
+          line: line_number.toString(),
+          message: line
+        });
+      }
+    }.bind(matches));
+    return matches;
+  }
 };
 ```
 
@@ -143,7 +139,9 @@ Option            | Required       | Description
 `sh`              | *[optional]*   | If `true`, the combined command and arguments will be passed to `/bin/sh`. Default `true`.
 `cwd`             | *[optional]*   | The working directory for the command. E.g. what `.` resolves to.
 `env`             | *[optional]*   | An object of environment variables and their values to set
-`errorMatch`      | *[optional]*   | A (list of) regular expressions to match output to a file, row and col. See [Error matching](#error-match) for details. (**JS only**: pass a function instead of regex to execute your own matching code)
+`errorMatch`      | *[optional]*   | A (list of) regular expressions to match output to a file, row and col. See [Error matching](#error-match) for details.
+`warningMatch`    | *[optional]*   | Like `errorMatch`, but is reported as just a warning
+`functionMatch`   | *[optional]*   | A (list of) javascript functions that return a list of match objects
 `keymap`          | *[optional]*   | A keymap string as defined by [`Atom`](https://atom.io/docs/latest/behind-atom-keymaps-in-depth). Pressing this key combination will trigger the target. Examples: `ctrl-alt-k` or `cmd-U`.
 `atomCommandName` | *[optional]*   | Command name to register which should be on the form of `namespace:command`. Read more about [Atom CommandRegistry](https://atom.io/docs/api/v1.4.1/CommandRegistry). The command will be available in the command palette and can be trigger from there. If this is returned by a build provider, the command can programatically be triggered by [dispatching](https://atom.io/docs/api/v1.4.1/CommandRegistry#instance-dispatch).
 `targets`         | *[optional]*   | Additional targets which can be used to build variations of your project.

--- a/lib/atom-build.js
+++ b/lib/atom-build.js
@@ -30,6 +30,8 @@ function createBuildConfig(build, name) {
     cwd: build.cwd,
     sh: build.sh,
     errorMatch: build.errorMatch,
+    functionMatch: build.functionMatch,
+    warningMatch: build.warningMatch,
     atomCommandName: build.atomCommandName,
     keymap: build.keymap
   };

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -332,7 +332,7 @@ export default class BuildView extends View {
     const content = this.getContent();
     let endPos = -1;
     let curPos = text.length;
-    // We need to decrese the size of `text` until we find a match. This is because
+    // We need to decrease the size of `text` until we find a match. This is because
     // terminal will insert line breaks ('\r\n') when width of terminal is reached.
     // It may have been that the middle of a matched error is on a line break.
     while (-1 === endPos && curPos > 0) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -72,7 +72,7 @@ export default {
       atom.notifications.addError('Error matching failed!', { detail: message });
     });
     this.errorMatcher.on('matched', (match) => {
-      this.buildView.scrollTo(match[0]);
+      match[0] && this.buildView.scrollTo(match[0]);
     });
   },
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -184,7 +184,7 @@ export default {
 
         let success = (0 === exitCode);
         if (atom.config.get('build.matchedErrorFailsBuild')) {
-          success = success && !this.errorMatcher.hasMatch();
+          success = success && !this.errorMatcher.getMatches().some(match => match.criticality === 'error' || match.type.toLowerCase() === 'error');
         }
 
         function extractRange(json) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -187,15 +187,47 @@ export default {
           success = success && !this.errorMatcher.hasMatch();
         }
 
+        function extract_range(json) {
+          return [
+            [ (json.line || 1) - 1, (json.col || 1) - 1 ],
+            [ (json.line_end || json.line || 1) - 1, (json.col_end || json.col || 1) - 1 ]
+          ];
+        }
+        function normalize_path(path) {
+          return npath.isAbsolute(path) ? path : npath.join(cwd, path);
+        }
+        function type2severity(type) {
+          switch (type && type.toLowerCase()) {
+            case 'error': return 'error';
+            case 'warning': return 'warning';
+            case 'trace': return 'info';
+            case 'note': return 'info';
+            default: return null;
+          }
+        }
+        function clean_severity(severity) {
+          switch (severity && severity.toLowerCase()) {
+            case 'error': return 'error';
+            case 'warning': return 'warning';
+            case 'info': return 'info';
+            default: return null;
+          }
+        }
+
         const npath = require('path');
         this.linter && this.linter.setMessages(this.errorMatcher.getMatches().map(match => ({
-          type: 'Error',
+          type: match.type || 'Error',
           text: match.message || 'Error from build',
-          filePath: npath.isAbsolute(match.file) ? match.file : npath.join(cwd, match.file),
-          range: [
-            [ (match.line || 1) - 1, (match.col || 1) - 1 ],
-            [ (match.line_end || match.line || 1) - 1, (match.col_end || match.col || 1) - 1 ]
-          ]
+          filePath: normalize_path(match.file),
+          severity: clean_severity(match.severity) || type2severity(match.type) || 'error',
+          range: extract_range(match),
+          trace: match.trace && match.trace.map(trace => ({
+            type: trace.type || 'Trace',
+            text: trace.message || 'Trace in build',
+            filePath: trace.file && normalize_path(trace.file),
+            severity: clean_severity(trace.severity) || type2severity(trace.type) || 'info',
+            range: extract_range(trace),
+          })),
         })));
 
         if (atom.config.get('build.beepWhenDone')) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -187,16 +187,16 @@ export default {
           success = success && !this.errorMatcher.hasMatch();
         }
 
-        function extract_range(json) {
+        function extractRange(json) {
           return [
             [ (json.line || 1) - 1, (json.col || 1) - 1 ],
             [ (json.line_end || json.line || 1) - 1, (json.col_end || json.col || 1) - 1 ]
           ];
         }
-        function normalize_path(path) {
-          return npath.isAbsolute(path) ? path : npath.join(cwd, path);
+        function normalizePath(p) {
+          return require('path').isAbsolute(p) ? p : require('path').join(cwd, p);
         }
-        function type2severity(type) {
+        function typeToSeverity(type) {
           switch (type && type.toLowerCase()) {
             case 'error': return 'error';
             case 'warning': return 'warning';
@@ -205,7 +205,7 @@ export default {
             default: return null;
           }
         }
-        function clean_severity(severity) {
+        function cleanSeverity(severity) {
           switch (severity && severity.toLowerCase()) {
             case 'error': return 'error';
             case 'warning': return 'warning';
@@ -214,20 +214,19 @@ export default {
           }
         }
 
-        const npath = require('path');
         this.linter && this.linter.setMessages(this.errorMatcher.getMatches().map(match => ({
           type: match.type || 'Error',
           text: match.message || 'Error from build',
-          filePath: normalize_path(match.file),
-          severity: clean_severity(match.severity) || type2severity(match.type) || 'error',
-          range: extract_range(match),
+          filePath: normalizePath(match.file),
+          severity: cleanSeverity(match.severity) || typeToSeverity(match.type) || 'error',
+          range: extractRange(match),
           trace: match.trace && match.trace.map(trace => ({
             type: trace.type || 'Trace',
             text: trace.message || 'Trace in build',
-            filePath: trace.file && normalize_path(trace.file),
-            severity: clean_severity(trace.severity) || type2severity(trace.type) || 'info',
-            range: extract_range(trace),
-          })),
+            filePath: trace.file && normalizePath(trace.file),
+            severity: cleanSeverity(trace.severity) || typeToSeverity(trace.type) || 'info',
+            range: extractRange(trace)
+          }))
         })));
 
         if (atom.config.get('build.beepWhenDone')) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -180,7 +180,7 @@ export default {
 
       this.child.on('close', (exitCode) => {
         this.child = null;
-        this.errorMatcher.set(target.errorMatch, cwd, stdout + stderr);
+        this.errorMatcher.set(target, cwd, stdout + stderr);
 
         let success = (0 === exitCode);
         if (atom.config.get('build.matchedErrorFailsBuild')) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -184,7 +184,7 @@ export default {
 
         let success = (0 === exitCode);
         if (atom.config.get('build.matchedErrorFailsBuild')) {
-          success = success && !this.errorMatcher.getMatches().some(match => match.criticality === 'error' || match.type && match.type.toLowerCase() === 'error');
+          success = success && !this.errorMatcher.getMatches().some(match => match.type && match.type.toLowerCase() === 'error');
         }
 
         function extractRange(json) {
@@ -198,18 +198,10 @@ export default {
         }
         function typeToSeverity(type) {
           switch (type && type.toLowerCase()) {
+            case 'err':
             case 'error': return 'error';
+            case 'warn':
             case 'warning': return 'warning';
-            case 'trace': return 'info';
-            case 'note': return 'info';
-            default: return null;
-          }
-        }
-        function cleanSeverity(severity) {
-          switch (severity && severity.toLowerCase()) {
-            case 'error': return 'error';
-            case 'warning': return 'warning';
-            case 'info': return 'info';
             default: return null;
           }
         }
@@ -218,13 +210,13 @@ export default {
           type: match.type || 'Error',
           text: match.message || 'Error from build',
           filePath: normalizePath(match.file),
-          severity: cleanSeverity(match.severity) || typeToSeverity(match.type) || 'error',
+          severity: typeToSeverity(match.type),
           range: extractRange(match),
           trace: match.trace && match.trace.map(trace => ({
             type: trace.type || 'Trace',
             text: trace.message || 'Trace in build',
             filePath: trace.file && normalizePath(trace.file),
-            severity: cleanSeverity(trace.severity) || typeToSeverity(trace.type) || 'info',
+            severity: typeToSeverity(trace.type) || 'info',
             range: extractRange(trace)
           }))
         })));

--- a/lib/build.js
+++ b/lib/build.js
@@ -184,7 +184,7 @@ export default {
 
         let success = (0 === exitCode);
         if (atom.config.get('build.matchedErrorFailsBuild')) {
-          success = success && !this.errorMatcher.getMatches().some(match => match.criticality === 'error' || match.type.toLowerCase() === 'error');
+          success = success && !this.errorMatcher.getMatches().some(match => match.criticality === 'error' || match.type && match.type.toLowerCase() === 'error');
         }
 
         function extractRange(json) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -293,7 +293,7 @@ export default {
 
   consumeLinterRegistry(registry) {
     this.linter && this.linter.destroy();
-    const Linter = require('linter-integration');
+    const Linter = require('./linter-integration');
     this.linter = new Linter(registry);
   },
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -86,7 +86,7 @@ export default {
     this.statusBarView && this.statusBarView.destroy();
     this.buildView && this.buildView.destroy();
     this.saveConfirmView && this.saveConfirmView.destroy();
-    this.linter && this.linter.dispose();
+    this.linter && this.linter.destroy();
     this.targetManager.destroy();
 
     clearTimeout(this.finishedTimer);
@@ -102,7 +102,7 @@ export default {
     const BuildError = require('./build-error');
     const path = require('./utils').activePath();
     let buildTitle = '';
-    this.linter && this.linter.deleteMessages();
+    this.linter && this.linter.clear();
 
     Promise.resolve(this.targetManager.getTargets(path)).then(targets => {
       if (!targets || 0 === targets.length) {
@@ -187,39 +187,7 @@ export default {
           success = success && !this.errorMatcher.getMatches().some(match => match.type && match.type.toLowerCase() === 'error');
         }
 
-        function extractRange(json) {
-          return [
-            [ (json.line || 1) - 1, (json.col || 1) - 1 ],
-            [ (json.line_end || json.line || 1) - 1, (json.col_end || json.col || 1) - 1 ]
-          ];
-        }
-        function normalizePath(p) {
-          return require('path').isAbsolute(p) ? p : require('path').join(cwd, p);
-        }
-        function typeToSeverity(type) {
-          switch (type && type.toLowerCase()) {
-            case 'err':
-            case 'error': return 'error';
-            case 'warn':
-            case 'warning': return 'warning';
-            default: return null;
-          }
-        }
-
-        this.linter && this.linter.setMessages(this.errorMatcher.getMatches().map(match => ({
-          type: match.type || 'Error',
-          text: match.message || 'Error from build',
-          filePath: normalizePath(match.file),
-          severity: typeToSeverity(match.type),
-          range: extractRange(match),
-          trace: match.trace && match.trace.map(trace => ({
-            type: trace.type || 'Trace',
-            text: trace.message || 'Trace in build',
-            filePath: trace.file && normalizePath(trace.file),
-            severity: typeToSeverity(trace.type) || 'info',
-            range: extractRange(trace)
-          }))
-        })));
+        this.linter && this.linter.processMessages(this.errorMatcher.getMatches(), cwd);
 
         if (atom.config.get('build.beepWhenDone')) {
           atom.beep();
@@ -324,7 +292,9 @@ export default {
   },
 
   consumeLinterRegistry(registry) {
-    this.linter = registry.register({ name: 'Build' });
+    this.linter && this.linter.destroy();
+    const Linter = require('linter-integration');
+    this.linter = new Linter(registry);
   },
 
   consumeBuilder(builder) {

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -68,11 +68,11 @@ export default class ErrorMatcher extends EventEmitter {
 
   _parse() {
     this.currentMatch = [];
-    const self = this;
+
     // first run all functional matches
-    this.functions && this.functions.forEach((f, f_i) => {
-      this.currentMatch = this.currentMatch.concat(f(this.output).map((match, match_i) => {
-        match.id = 'error-match-function-' + f_i + '-' + match_i;
+    this.functions && this.functions.forEach((f, functionIndex) => {
+      this.currentMatch = this.currentMatch.concat(f(this.output).map((match, matchIndex) => {
+        match.id = 'error-match-function-' + functionIndex + '-' + matchIndex;
         match[0] = match.message;
         return match;
       }));
@@ -81,12 +81,12 @@ export default class ErrorMatcher extends EventEmitter {
     Object.keys(this.regex).forEach(kind => {
       // run all matches
       this.regex[kind] && this.regex[kind].forEach((regex, i) => {
-        regex && require('xregexp').forEach(this.output, regex, (match, match_i) => {
-          match.id = 'error-match-' + i + '-' + match_i;
+        regex && require('xregexp').forEach(this.output, regex, (match, matchIndex) => {
+          match.id = 'error-match-' + i + '-' + matchIndex;
           match.type = kind;
           this.currentMatch.push(match);
         });
-      })
+      });
     });
 
     this.currentMatch.sort((a, b) => a.index - b.index);
@@ -94,7 +94,7 @@ export default class ErrorMatcher extends EventEmitter {
     this.firstMatchId = (this.currentMatch.length > 0) ? this.currentMatch[0].id : null;
   }
 
-  _prepare_regex(regex) {
+  _prepareRegex(regex) {
     regex = regex || [];
     regex = (regex instanceof Array) ? regex : [ regex ];
 
@@ -112,17 +112,16 @@ export default class ErrorMatcher extends EventEmitter {
   set(target, cwd, output) {
     if (target.functionMatch) {
       this.functions = ((target.functionMatch instanceof Array) ? target.functionMatch : [ target.functionMatch ]).filter(f => {
-        if (typeof f != 'function') {
+        if (typeof f !== 'function') {
           this.emit('error', 'found functionMatch that is no function: ' + typeof f);
           return false;
-        } else {
-          return true;
         }
+        return true;
       });
     }
     this.regex = {
-      error: this._prepare_regex(target.errorMatch),
-      warning: this._prepare_regex(target.warningMatch),
+      error: this._prepareRegex(target.errorMatch),
+      warning: this._prepareRegex(target.warningMatch)
     };
 
     this.cwd = cwd;

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -73,7 +73,6 @@ export default class ErrorMatcher extends EventEmitter {
     this.functions && this.functions.forEach((f, functionIndex) => {
       this.currentMatch = this.currentMatch.concat(f(this.output).map((match, matchIndex) => {
         match.id = 'error-match-function-' + functionIndex + '-' + matchIndex;
-        match[0] = match.message;
         return match;
       }));
     });

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -119,8 +119,8 @@ export default class ErrorMatcher extends EventEmitter {
       });
     }
     this.regex = {
-      error: this._prepareRegex(target.errorMatch),
-      warning: this._prepareRegex(target.warningMatch)
+      Error: this._prepareRegex(target.errorMatch),
+      Warning: this._prepareRegex(target.warningMatch)
     };
 
     this.cwd = cwd;

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -69,18 +69,24 @@ export default class ErrorMatcher extends EventEmitter {
   _parse() {
     this.currentMatch = [];
     const self = this;
-    const matchFunction = function (match, i, string, regex) {
-      match.id = 'error-match-' + self.regex.indexOf(regex) + '-' + i;
-      this.push(match);
-    };
-    this.regex.forEach((regex) => {
-      if (typeof regex === 'function') {
-        regex(this.output).forEach(function (match) {
-          this.push(match);
-        }.bind(this.currentMatch));
-      } else {
-        require('xregexp').forEach(this.output, regex, matchFunction.bind(this.currentMatch));
-      }
+    // first run all functional matches
+    this.functions && this.functions.forEach((f, f_i) => {
+      this.currentMatch = this.currentMatch.concat(f(this.output).map((match, match_i) => {
+        match.id = 'error-match-function-' + f_i + '-' + match_i;
+        match[0] = match.message;
+        return match;
+      }));
+    });
+    // then for all match kinds
+    Object.keys(this.regex).forEach(kind => {
+      // run all matches
+      this.regex[kind] && this.regex[kind].forEach((regex, i) => {
+        regex && require('xregexp').forEach(this.output, regex, (match, match_i) => {
+          match.id = 'error-match-' + i + '-' + match_i;
+          match.type = kind;
+          this.currentMatch.push(match);
+        });
+      })
     });
 
     this.currentMatch.sort((a, b) => a.index - b.index);
@@ -88,14 +94,11 @@ export default class ErrorMatcher extends EventEmitter {
     this.firstMatchId = (this.currentMatch.length > 0) ? this.currentMatch[0].id : null;
   }
 
-  set(regex, cwd, output) {
+  _prepare_regex(regex) {
     regex = regex || [];
     regex = (regex instanceof Array) ? regex : [ regex ];
 
-    this.regex = regex.map((r) => {
-      if (typeof r === 'function') {
-        return r;
-      }
+    return regex.map(r => {
       try {
         const XRegExp = require('xregexp');
         return XRegExp(r);
@@ -103,7 +106,24 @@ export default class ErrorMatcher extends EventEmitter {
         this.emit('error', 'Error parsing regex. ' + err.message);
         return null;
       }
-    }).filter(Boolean);
+    });
+  }
+
+  set(target, cwd, output) {
+    if (target.functionMatch) {
+      this.functions = ((target.functionMatch instanceof Array) ? target.functionMatch : [ target.functionMatch ]).filter(f => {
+        if (typeof f != 'function') {
+          this.emit('error', 'found functionMatch that is no function: ' + typeof f);
+          return false;
+        } else {
+          return true;
+        }
+      });
+    }
+    this.regex = {
+      error: this._prepare_regex(target.errorMatch),
+      warning: this._prepare_regex(target.warningMatch),
+    };
 
     this.cwd = cwd;
     this.output = output;

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -89,19 +89,6 @@ export default class ErrorMatcher extends EventEmitter {
       });
     });
 
-    this.currentMatch.forEach(match => {
-      switch (match.criticality) {
-        case 'error':
-        case 'warning':
-        case 'info':
-        case null:
-        case undefined: break;
-        default: {
-          this.emit('error', 'Invalid match criticality: ' + match.criticality.toString());
-        }
-      }
-    });
-
     this.currentMatch.sort((a, b) => a.index - b.index);
 
     this.firstMatchId = (this.currentMatch.length > 0) ? this.currentMatch[0].id : null;

--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -73,6 +73,7 @@ export default class ErrorMatcher extends EventEmitter {
     this.functions && this.functions.forEach((f, functionIndex) => {
       this.currentMatch = this.currentMatch.concat(f(this.output).map((match, matchIndex) => {
         match.id = 'error-match-function-' + functionIndex + '-' + matchIndex;
+        match.type = match.type || 'Error';
         return match;
       }));
     });
@@ -86,6 +87,19 @@ export default class ErrorMatcher extends EventEmitter {
           this.currentMatch.push(match);
         });
       });
+    });
+
+    this.currentMatch.forEach(match => {
+      switch (match.criticality) {
+        case 'error':
+        case 'warning':
+        case 'info':
+        case null:
+        case undefined: break;
+        default: {
+          this.emit('error', 'Invalid match criticality: ' + match.criticality.toString());
+        }
+      }
     });
 
     this.currentMatch.sort((a, b) => a.index - b.index);

--- a/lib/linter-integration.js
+++ b/lib/linter-integration.js
@@ -1,0 +1,49 @@
+'use babel';
+
+class Linter {
+  constructor(registry) {
+    this.linter = registry.register({ name: 'Build' });
+  }
+  destroy() {
+    this.linter.dispose();
+  }
+  clear() {
+    this.linter.deleteMessages();
+  }
+  processMessages(messages, cwd) {
+    function extractRange(json) {
+      return [
+        [ (json.line || 1) - 1, (json.col || 1) - 1 ],
+        [ (json.line_end || json.line || 1) - 1, (json.col_end || json.col || 1) - 1 ]
+      ];
+    }
+    function normalizePath(p) {
+      return require('path').isAbsolute(p) ? p : require('path').join(cwd, p);
+    }
+    function typeToSeverity(type) {
+      switch (type && type.toLowerCase()) {
+        case 'err':
+        case 'error': return 'error';
+        case 'warn':
+        case 'warning': return 'warning';
+        default: return null;
+      }
+    }
+    this.linter.setMessages(messages.map(match => ({
+      type: match.type || 'Error',
+      text: match.message || 'Error from build',
+      filePath: normalizePath(match.file),
+      severity: typeToSeverity(match.type),
+      range: extractRange(match),
+      trace: match.trace && match.trace.map(trace => ({
+        type: trace.type || 'Trace',
+        text: trace.message || 'Trace in build',
+        filePath: trace.file && normalizePath(trace.file),
+        severity: typeToSeverity(trace.type) || 'info',
+        range: extractRange(trace)
+      }))
+    })));
+  }
+}
+
+export default Linter;

--- a/spec/build-error-match-spec.js
+++ b/spec/build-error-match-spec.js
@@ -15,6 +15,7 @@ describe('Error Match', () => {
   const errorMatchLongOutputAtomBuildFile = __dirname + '/fixture/.atom-build.error-match-long-output.json';
   const errorMatchMultiMatcherAtomBuildFile = __dirname + '/fixture/.atom-build.error-match-multiple-errorMatch.json';
   const errorMatchFunction = __dirname + '/fixture/.atom-build.error-match-function.js';
+  const matchFunctionWarning = __dirname + '/fixture/.atom-build.match-function-warning.js';
   const originalHomedirFn = os.homedir;
 
   let directory = null;
@@ -559,6 +560,35 @@ describe('Error Match', () => {
         expect(bufferPosition.row).toEqual(1);
         expect(bufferPosition.column).toEqual(0);
         atom.workspace.getActivePane().destroyActiveItem();
+      });
+
+      runs(() => {
+        atom.commands.dispatch(workspaceElement, 'build:error-match');
+      });
+
+      waitsFor(() => {
+        return atom.workspace.getActiveTextEditor();
+      });
+
+      runs(() => {
+        const editor = atom.workspace.getActiveTextEditor();
+        const bufferPosition = editor.getCursorBufferPosition();
+        expect(editor.getTitle()).toEqual('.atom-build.js');
+        expect(bufferPosition.row).toEqual(4);
+        expect(bufferPosition.column).toEqual(0);
+      });
+    });
+
+    it('should be possible to change the type of the match to something other than `Error`', () => {
+      expect(workspaceElement.querySelector('.build')).not.toExist();
+
+      fs.writeFileSync(directory + '.atom-build.js', fs.readFileSync(matchFunctionWarning));
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
+      waitsFor(() => {
+        return workspaceElement.querySelector('.build .title') &&
+          workspaceElement.querySelector('.build .title').classList.contains('error');
       });
 
       runs(() => {

--- a/spec/build-error-match-spec.js
+++ b/spec/build-error-match-spec.js
@@ -16,6 +16,7 @@ describe('Error Match', () => {
   const errorMatchMultiMatcherAtomBuildFile = __dirname + '/fixture/.atom-build.error-match-multiple-errorMatch.json';
   const errorMatchFunction = __dirname + '/fixture/.atom-build.error-match-function.js';
   const matchFunctionWarning = __dirname + '/fixture/.atom-build.match-function-warning.js';
+  const warningMatchAtomBuildFile = __dirname + '/fixture/.atom-build.warning-match.json';
   const originalHomedirFn = os.homedir;
 
   let directory = null;
@@ -94,6 +95,36 @@ describe('Error Match', () => {
       });
 
       runs(() => {
+        atom.commands.dispatch(workspaceElement, 'build:error-match');
+      });
+
+      waitsFor(() => {
+        return atom.workspace.getActiveTextEditor();
+      });
+
+      runs(() => {
+        const editor = atom.workspace.getActiveTextEditor();
+        const bufferPosition = editor.getCursorBufferPosition();
+        expect(editor.getTitle()).toEqual('.atom-build.json');
+        expect(bufferPosition.row).toEqual(2);
+        expect(bufferPosition.column).toEqual(7);
+      });
+    });
+
+    it('should place the line and column on warning in correct file', () => {
+      expect(workspaceElement.querySelector('.build')).not.toExist();
+      atom.config.set('build.matchedErrorFailsBuild', true);
+
+      fs.writeFileSync(directory + '.atom-build.json', fs.readFileSync(warningMatchAtomBuildFile));
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
+      waitsFor(() => {
+        return workspaceElement.querySelector('.build .title');
+      });
+
+      runs(() => {
+        expect(workspaceElement.querySelector('.build .title').classList.contains('error')).not.toExist()
         atom.commands.dispatch(workspaceElement, 'build:error-match');
       });
 

--- a/spec/build-error-match-spec.js
+++ b/spec/build-error-match-spec.js
@@ -125,7 +125,7 @@ describe('Error Match', () => {
       });
 
       runs(() => {
-        expect(workspaceElement.querySelector('.build .title').classList.contains('error')).not.toExist()
+        expect(workspaceElement.querySelector('.build .title').classList.contains('error')).not.toExist();
         atom.commands.dispatch(workspaceElement, 'build:error-match');
       });
 

--- a/spec/build-error-match-spec.js
+++ b/spec/build-error-match-spec.js
@@ -120,7 +120,8 @@ describe('Error Match', () => {
       runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
 
       waitsFor(() => {
-        return workspaceElement.querySelector('.build .title');
+        return workspaceElement.querySelector('.build .title') &&
+          workspaceElement.querySelector('.build .title').classList.contains('success');
       });
 
       runs(() => {
@@ -619,7 +620,7 @@ describe('Error Match', () => {
 
       waitsFor(() => {
         return workspaceElement.querySelector('.build .title') &&
-          workspaceElement.querySelector('.build .title').classList.contains('error');
+          workspaceElement.querySelector('.build .title').classList.contains('success');
       });
 
       runs(() => {

--- a/spec/build-error-match-spec.js
+++ b/spec/build-error-match-spec.js
@@ -58,7 +58,7 @@ describe('Error Match', () => {
     // FIXME: try to figure out why atom still holds on to the directory/files on windows
     try {
       fs.removeSync(directory);
-    } catch {
+    } catch (err) {
     }
     os.homedir = originalHomedirFn;
   });

--- a/spec/build-error-match-spec.js
+++ b/spec/build-error-match-spec.js
@@ -55,7 +55,11 @@ describe('Error Match', () => {
   });
 
   afterEach(() => {
-    fs.removeSync(directory);
+    // FIXME: try to figure out why atom still holds on to the directory/files on windows
+    try {
+      fs.removeSync(directory);
+    } catch {
+    }
     os.homedir = originalHomedirFn;
   });
 

--- a/spec/build-error-match-spec.js
+++ b/spec/build-error-match-spec.js
@@ -59,6 +59,7 @@ describe('Error Match', () => {
     try {
       fs.removeSync(directory);
     } catch (err) {
+      // Failed to clean up, ignore this.
     }
     os.homedir = originalHomedirFn;
   });

--- a/spec/fixture/.atom-build.error-match-function.js
+++ b/spec/fixture/.atom-build.error-match-function.js
@@ -3,7 +3,7 @@ module.exports = {
   args: [ 'cake' ],
   name: 'from js',
   sh: true,
-  errorMatch: function (terminal_output) {
+  functionMatch: function (terminal_output) {
     return [
         {
             file: '.atom-build.js',

--- a/spec/fixture/.atom-build.error-match-no-exit1.json
+++ b/spec/fixture/.atom-build.error-match-no-exit1.json
@@ -1,0 +1,4 @@
+{
+	"cmd": "echo 'file:.atom-build.json,line:3,column:8' && exit 0",
+	"errorMatch": "file:(?<file>[^,]+),line:(?<line>\\d+),column:(?<col>\\d+)"
+}

--- a/spec/fixture/.atom-build.match-function-change-dirs.js
+++ b/spec/fixture/.atom-build.match-function-change-dirs.js
@@ -1,0 +1,29 @@
+module.exports = {
+  cmd: 'cat',
+  args: [ 'change_dir_output.txt' ],
+  name: 'change dir',
+  sh: true,
+  functionMatch: function (output) {
+    const enterDir = /^make\[\d+\]: Entering directory '([^']+)'$/;
+    const error = /^([^:]+):(\d+):(\d+): error: (.+)$/;
+    const array = [];
+    var dir = null;
+    output.split(/\r?\n/).forEach(line => {
+      const dir_match = enterDir.exec(line);
+      if (dir_match) {
+        dir = dir_match[1];
+      } else {
+        const error_match = error.exec(line);
+        if (error_match) {
+          array.push({
+            file: dir ? dir + '/' + error_match[1] : error_match[1],
+            line: error_match[2],
+            col: error_match[3],
+            message: error_match[4],
+          });
+        }
+      }
+    });
+    return array;
+  }
+};

--- a/spec/fixture/.atom-build.match-function-trace.js
+++ b/spec/fixture/.atom-build.match-function-trace.js
@@ -1,0 +1,21 @@
+module.exports = {
+  cmd: 'echo',
+  args: [ 'cake' ],
+  name: 'from js',
+  sh: true,
+  errorMatch: function (terminal_output) {
+    return [
+      {
+        file: '.atom-build.js',
+        line: '6',
+        type: 'Error',
+        trace: [
+          {
+            type: 'Explanation',
+            message: 'insert great explanation here',
+          }
+        ],
+      }
+    ];
+  }
+};

--- a/spec/fixture/.atom-build.match-function-trace.js
+++ b/spec/fixture/.atom-build.match-function-trace.js
@@ -3,7 +3,7 @@ module.exports = {
   args: [ 'cake' ],
   name: 'from js',
   sh: true,
-  errorMatch: function (terminal_output) {
+  functionMatch: function (terminal_output) {
     return [
       {
         file: '.atom-build.js',

--- a/spec/fixture/.atom-build.match-function-warning.js
+++ b/spec/fixture/.atom-build.match-function-warning.js
@@ -3,7 +3,7 @@ module.exports = {
   args: [ 'cake' ],
   name: 'from js',
   sh: true,
-  errorMatch: function (terminal_output) {
+  functionMatch: function (terminal_output) {
     return [
       {
         file: '.atom-build.js',

--- a/spec/fixture/.atom-build.match-function-warning.js
+++ b/spec/fixture/.atom-build.match-function-warning.js
@@ -1,0 +1,16 @@
+module.exports = {
+  cmd: 'echo',
+  args: [ 'cake' ],
+  name: 'from js',
+  sh: true,
+  errorMatch: function (terminal_output) {
+    return [
+      {
+        file: '.atom-build.js',
+        line: '5',
+        type: 'Warning',
+        message: 'mildly bad things',
+      }
+    ];
+  }
+};

--- a/spec/fixture/.atom-build.warning-match.json
+++ b/spec/fixture/.atom-build.warning-match.json
@@ -1,0 +1,4 @@
+{
+	"cmd": "echo file:.atom-build.json,line:3,column:8 && echo file:.atom-build.json,line:2,column:5 && exit 0",
+	"warningMatch": "file:(?<file>[^,]+),line:(?<line>\\d+),column:(?<col>\\d+)"
+}

--- a/spec/fixture/change_dir_output.txt
+++ b/spec/fixture/change_dir_output.txt
@@ -1,0 +1,9 @@
+make  all-recursive
+make[1]: Entering directory 'foo'
+Making all in src
+make[2]: Entering directory 'foo/src'
+  CC       testmake.o
+testmake.c: In function 'main':
+testmake.c:3:5: error: unknown type name 'error'
+     error is here!
+     ^

--- a/spec/linter-intergration-spec.js
+++ b/spec/linter-intergration-spec.js
@@ -65,7 +65,7 @@ describe('Linter Integration', () => {
             text: 'Error from build',
             type: 'Error',
             severity: 'error',
-            trace: undefined,
+            trace: undefined
           },
           {
             filePath: join(directory, '.atom-build.json'),
@@ -73,7 +73,7 @@ describe('Linter Integration', () => {
             text: 'Error from build',
             type: 'Error',
             severity: 'error',
-            trace: undefined,
+            trace: undefined
           }
         ]);
       });
@@ -99,7 +99,7 @@ describe('Linter Integration', () => {
             text: 'very bad things',
             type: 'Error',
             severity: 'error',
-            trace: undefined,
+            trace: undefined
           }
         ]);
       });
@@ -125,7 +125,7 @@ describe('Linter Integration', () => {
             text: 'mildly bad things',
             type: 'Warning',
             severity: 'warning',
-            trace: undefined,
+            trace: undefined
           }
         ]);
       });
@@ -157,9 +157,9 @@ describe('Linter Integration', () => {
                 severity: 'info',
                 type: 'Explanation',
                 range: [ [0, 0], [0, 0]],
-                filePath: undefined,
+                filePath: undefined
               }
-            ],
+            ]
           }
         ]);
       });
@@ -185,7 +185,7 @@ describe('Linter Integration', () => {
             text: 'very bad things',
             type: 'Error',
             severity: 'error',
-            trace: undefined,
+            trace: undefined
           }
         ]);
         fs.writeFileSync(join(directory, '.atom-build.json'), JSON.stringify({

--- a/spec/linter-intergration-spec.js
+++ b/spec/linter-intergration-spec.js
@@ -105,7 +105,7 @@ describe('Linter Integration', () => {
       });
     });
 
-    fit('should emit warnings just like errors', () => {
+    it('should emit warnings just like errors', () => {
       expect(dummyPackage.hasRegistered()).toEqual(true);
       fs.writeFileSync(join(directory, '.atom-build.js'), fs.readFileSync(join(__dirname, 'fixture', '.atom-build.match-function-warning.js')));
 
@@ -131,7 +131,7 @@ describe('Linter Integration', () => {
       });
     });
 
-    fit('should attach traces to matches where applicable', () => {
+    it('should attach traces to matches where applicable', () => {
       expect(dummyPackage.hasRegistered()).toEqual(true);
       fs.writeFileSync(join(directory, '.atom-build.js'), fs.readFileSync(join(__dirname, 'fixture', '.atom-build.match-function-trace.js')));
 

--- a/spec/linter-intergration-spec.js
+++ b/spec/linter-intergration-spec.js
@@ -63,13 +63,17 @@ describe('Linter Integration', () => {
             filePath: join(directory, '.atom-build.json'),
             range: [ [2, 7], [2, 7] ],
             text: 'Error from build',
-            type: 'Error'
+            type: 'Error',
+            severity: 'error',
+            trace: undefined,
           },
           {
             filePath: join(directory, '.atom-build.json'),
             range: [ [1, 4], [1, 4] ],
             text: 'Error from build',
-            type: 'Error'
+            type: 'Error',
+            severity: 'error',
+            trace: undefined,
           }
         ]);
       });
@@ -93,7 +97,69 @@ describe('Linter Integration', () => {
             filePath: join(directory, '.atom-build.json'),
             range: [ [2, 7], [2, 7] ],
             text: 'very bad things',
-            type: 'Error'
+            type: 'Error',
+            severity: 'error',
+            trace: undefined,
+          }
+        ]);
+      });
+    });
+
+    fit('should emit warnings just like errors', () => {
+      expect(dummyPackage.hasRegistered()).toEqual(true);
+      fs.writeFileSync(join(directory, '.atom-build.js'), fs.readFileSync(join(__dirname, 'fixture', '.atom-build.match-function-warning.js')));
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
+      waitsFor(() => {
+        return workspaceElement.querySelector('.build .title') &&
+          workspaceElement.querySelector('.build .title').classList.contains('error');
+      });
+
+      runs(() => {
+        const linter = dummyPackage.getLinter();
+        expect(linter.messages).toEqual([
+          {
+            filePath: join(directory, '.atom-build.js'),
+            range: [ [4, 0], [4, 0] ],
+            text: 'mildly bad things',
+            type: 'Warning',
+            severity: 'warning',
+            trace: undefined,
+          }
+        ]);
+      });
+    });
+
+    fit('should attach traces to matches where applicable', () => {
+      expect(dummyPackage.hasRegistered()).toEqual(true);
+      fs.writeFileSync(join(directory, '.atom-build.js'), fs.readFileSync(join(__dirname, 'fixture', '.atom-build.match-function-trace.js')));
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
+      waitsFor(() => {
+        return workspaceElement.querySelector('.build .title') &&
+          workspaceElement.querySelector('.build .title').classList.contains('error');
+      });
+
+      runs(() => {
+        const linter = dummyPackage.getLinter();
+        expect(linter.messages).toEqual([
+          {
+            filePath: join(directory, '.atom-build.js'),
+            range: [ [5, 0], [5, 0] ],
+            text: 'Error from build',
+            type: 'Error',
+            severity: 'error',
+            trace: [
+              {
+                text: 'insert great explanation here',
+                severity: 'info',
+                type: 'Explanation',
+                range: [ [0, 0], [0, 0]],
+                filePath: undefined,
+              }
+            ],
           }
         ]);
       });
@@ -117,7 +183,9 @@ describe('Linter Integration', () => {
             filePath: join(directory, '.atom-build.json'),
             range: [ [2, 7], [2, 7] ],
             text: 'very bad things',
-            type: 'Error'
+            type: 'Error',
+            severity: 'error',
+            trace: undefined,
           }
         ]);
         fs.writeFileSync(join(directory, '.atom-build.json'), JSON.stringify({

--- a/spec/linter-intergration-spec.js
+++ b/spec/linter-intergration-spec.js
@@ -113,7 +113,7 @@ describe('Linter Integration', () => {
 
       waitsFor(() => {
         return workspaceElement.querySelector('.build .title') &&
-          workspaceElement.querySelector('.build .title').classList.contains('error');
+          workspaceElement.querySelector('.build .title').classList.contains('success');
       });
 
       runs(() => {


### PR DESCRIPTION
This adds `warningMatch` and improves `functionMatch` to allow build providers to emit almost any kind of lint that is specified here: https://github.com/steelbrain/linter/wiki/Linter-API#messages

An example of a modified `build-cargo`:
![pic of traces and custom error types](https://cloud.githubusercontent.com/assets/332036/15097688/ddfc170c-1523-11e6-8394-d24a79d125ea.png)

fixes #408