### PR TITLE
Remove UUID dependency

### DIFF
--- a/lib/google-analytics.js
+++ b/lib/google-analytics.js
@@ -1,5 +1,12 @@
 'use babel';
 
+function uuid() {
+  function s4() {
+    return Math.floor((1 + Math.random()) * 0x10000).toString(16).substring(1);
+  }
+  return `${s4()}${s4()}-${s4()}-${s4()}-${s4()}-${s4()}${s4()}${s4()}`;
+}
+
 export default class GoogleAnalytics {
   static getCid(cb) {
     if (this.cid) {
@@ -9,7 +16,7 @@ export default class GoogleAnalytics {
 
     require('getmac').getMac((error, macAddress) => {
       return error ?
-        cb(this.cid = require('node-uuid').v4()) :
+        cb(this.cid = uuid()) :
         cb(this.cid = require('crypto').createHash('sha1').update(macAddress, 'utf8').digest('hex'));
     });
   }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/noseglid/atom-build",
   "license": "MIT",
   "engines": {
-    "atom": ">=0.50.0"
+    "atom": ">=1.0.0"
   },
   "dependencies": {
     "atom-package-deps": "^4.0.1",
@@ -15,7 +15,6 @@
     "cson-parser": "^1.3.0",
     "getmac": "^1.0.7",
     "js-yaml": "^3.4.6",
-    "node-uuid": "^1.4.3",
     "term.js": "https://github.com/jeremyramin/term.js/tarball/de1635fc2695e7d8165012d3b1d007d7ce60eea2",
     "tree-kill": "^1.0.0",
     "xregexp": "^3.1.0"
@@ -52,7 +51,7 @@
     }
   },
   "scripts": {
-    "test": "./node_modules/.bin/eslint ."
+    "test": "eslint ."
   },
   "keywords": [
     "build",


### PR DESCRIPTION
It's easy enough to generate a "good enough" unique id.
No need to pull in a dependency for it.