### PR TITLE
Make use of notification stack option in TargetManager

### DIFF
--- a/lib/target-manager.js
+++ b/lib/target-manager.js
@@ -81,7 +81,8 @@ class TargetManager extends EventEmitter {
                 });
               } else {
                 atom.notifications.addError('Ooops. Something went wrong.', {
-                  detail: err.message + (err.stack ? '\n' + err.stack : ''),
+                  detail: err.message,
+                  stack: err.stack,
                   dismissable: true
                 });
               }
@@ -122,7 +123,8 @@ class TargetManager extends EventEmitter {
         pathTarget.loading = false;
       }).catch(err => {
         atom.notifications.addError('Ooops. Something went wrong.', {
-          detail: err.message + (err.stack ? '\n' + err.stack : ''),
+          detail: err.message,
+          stack: err.stack,
           dismissable: true
         });
       });
@@ -151,7 +153,8 @@ class TargetManager extends EventEmitter {
       }
     }).catch(err => {
       atom.notifications.addError('Ooops. Something went wrong.', {
-        detail: err.message + (err.stack ? '\n' + err.stack : ''),
+        detail: err.message,
+        stack: err.stack,
         dismissable: true
       });
     });


### PR DESCRIPTION
There are several spots in the `TargetManager` that spit out Atom notifications for errors, that contain stack traces. These stack traces can be shown in the notification with the `stack` option, rather than appending them to the details. The notification will show a pretty little toggle-able stack trace.

See atom/notifications#126. It's most likely safe to use this option, since it's just a property containing a string - and that's probably not likely to change in the future.