### PR TITLE
Make error notification more descriptive

### DIFF
--- a/lib/target-manager.js
+++ b/lib/target-manager.js
@@ -80,7 +80,8 @@ class TargetManager extends EventEmitter {
                   dismissable: true
                 });
               } else {
-                atom.notifications.addError('Ooops. Something went wrong.', {
+                const toolName = tool.getNiceName();
+                atom.notifications.addError('Ooops. Something went wrong' + (toolName ? ' in the ' + toolName + ' build provider' : '') + '.', {
                   detail: err.message,
                   stack: err.stack,
                   dismissable: true


### PR DESCRIPTION
This simply adds the name of the build provider to the notification when an error occurs while getting the build settings.