### PR TITLE
Convert platform-specific path delimiters to native platform delimiters.

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -130,6 +130,7 @@ export default {
     }).then(target => {
       const replace = require('./utils').replace;
       const pathFix = require('./utils').pathFix;
+      const cmdQuote = require('./utils').cmdQuote;
 
       const env = Object.assign({}, process.env, target.env);
       Object.keys(env).forEach(key => {
@@ -143,6 +144,11 @@ export default {
       const shCmd = isWin ? 'cmd' : '/bin/sh';
       const shCmdArg = isWin ? '/C' : '-c';
 
+      let execAndArgs = [exec, ...args];
+      if (!isWin) {
+        execAndArgs = [cmdQuote(execAndArgs)];
+      }
+
       // Store this as we need to re-set it after postBuild
       buildTitle = [ (target.sh ? `${shCmd} ${shCmdArg} ${exec}` : exec ), ...args, '\n'].join(' ');
 
@@ -150,7 +156,7 @@ export default {
       if (target.sh) {
         this.child = require('child_process').spawn(
           shCmd,
-          [ shCmdArg, exec ].concat(args),
+          [ shCmdArg, ...execAndArgs ],
           { cwd: cwd, env: env }
         );
       } else {

--- a/lib/build.js
+++ b/lib/build.js
@@ -129,12 +129,14 @@ export default {
       return Promise.resolve(target.preBuild ? target.preBuild() : null).then(() => target);
     }).then(target => {
       const replace = require('./utils').replace;
+      const pathQuote = require('./utils').pathQuote;
+
       const env = Object.assign({}, process.env, target.env);
       Object.keys(env).forEach(key => {
         env[key] = replace(env[key], target.env);
       });
 
-      const exec = replace(target.exec, target.env);
+      const exec = pathQuote(replace(target.exec, target.env));
       const args = target.args.map(arg => replace(arg, target.env));
       const cwd = replace(target.cwd, target.env);
       const isWin = process.platform === 'win32';
@@ -142,13 +144,13 @@ export default {
       const shCmdArg = isWin ? '/C' : '-c';
 
       // Store this as we need to re-set it after postBuild
-      buildTitle = [ (target.sh ? `${shCmd} ${shCmdArg} "${exec}"` : '"' + exec + '"' ), ...args, '\n'].join(' ');
+      buildTitle = [ (target.sh ? `${shCmd} ${shCmdArg} "${exec}"` : exec), ...args, '\n'].join(' ');
 
       this.buildView.setHeading(buildTitle);
       if (target.sh) {
         this.child = require('child_process').spawn(
           shCmd,
-          [ shCmdArg, [ '"' + exec + '"' ].concat(args).join(' ')],
+          [ shCmdArg, [ exec ].concat(args).join(' ')],
           { cwd: cwd, env: env }
         );
       } else {

--- a/lib/build.js
+++ b/lib/build.js
@@ -144,7 +144,7 @@ export default {
       const shCmdArg = isWin ? '/C' : '-c';
 
       // Store this as we need to re-set it after postBuild
-      buildTitle = [ (target.sh ? `${shCmd} ${shCmdArg} "${exec}"` : exec), ...args, '\n'].join(' ');
+      buildTitle = [ (target.sh ? `${shCmd} ${shCmdArg} ${exec}` : exec ), ...args, '\n'].join(' ');
 
       this.buildView.setHeading(buildTitle);
       if (target.sh) {

--- a/lib/build.js
+++ b/lib/build.js
@@ -130,23 +130,22 @@ export default {
     }).then(target => {
       const replace = require('./utils').replace;
       const pathFix = require('./utils').pathFix;
-      const cmdQuote = require('./utils').cmdQuote;
 
       const env = Object.assign({}, process.env, target.env);
       Object.keys(env).forEach(key => {
         env[key] = replace(env[key], target.env);
       });
 
-      const exec = pathFix(replace(target.exec, target.env));
+      const exec = replace(pathFix(target.exec), target.env);
       const args = target.args.map(arg => replace(arg, target.env));
-      const cwd = replace(target.cwd, target.env);
+      const cwd = replace(pathFix(target.cwd), target.env);
       const isWin = process.platform === 'win32';
       const shCmd = isWin ? 'cmd' : '/bin/sh';
       const shCmdArg = isWin ? '/C' : '-c';
 
       let execAndArgs = [exec, ...args];
       if (!isWin) {
-        execAndArgs = [cmdQuote(execAndArgs)];
+        execAndArgs = [execAndArgs.join(' ')];
       }
 
       // Store this as we need to re-set it after postBuild

--- a/lib/build.js
+++ b/lib/build.js
@@ -129,14 +129,14 @@ export default {
       return Promise.resolve(target.preBuild ? target.preBuild() : null).then(() => target);
     }).then(target => {
       const replace = require('./utils').replace;
-      const pathQuote = require('./utils').pathQuote;
+      const pathFix = require('./utils').pathFix;
 
       const env = Object.assign({}, process.env, target.env);
       Object.keys(env).forEach(key => {
         env[key] = replace(env[key], target.env);
       });
 
-      const exec = pathQuote(replace(target.exec, target.env));
+      const exec = pathFix(replace(target.exec, target.env));
       const args = target.args.map(arg => replace(arg, target.env));
       const cwd = replace(target.cwd, target.env);
       const isWin = process.platform === 'win32';
@@ -150,7 +150,7 @@ export default {
       if (target.sh) {
         this.child = require('child_process').spawn(
           shCmd,
-          [ shCmdArg, [ exec ].concat(args).join(' ')],
+          [ shCmdArg, exec ].concat(args),
           { cwd: cwd, env: env }
         );
       } else {

--- a/lib/build.js
+++ b/lib/build.js
@@ -142,13 +142,13 @@ export default {
       const shCmdArg = isWin ? '/C' : '-c';
 
       // Store this as we need to re-set it after postBuild
-      buildTitle = [ (target.sh ? `${shCmd} ${shCmdArg} ${exec}` : exec ), ...args, '\n'].join(' ');
+      buildTitle = [ (target.sh ? `${shCmd} ${shCmdArg} "${exec}"` : '"' + exec + '"' ), ...args, '\n'].join(' ');
 
       this.buildView.setHeading(buildTitle);
       if (target.sh) {
         this.child = require('child_process').spawn(
           shCmd,
-          [ shCmdArg, [ exec ].concat(args).join(' ')],
+          [ shCmdArg, [ '"' + exec + '"' ].concat(args).join(' ')],
           { cwd: cwd, env: env }
         );
       } else {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -84,19 +84,19 @@ const replace = (value = '', targetEnv) => {
   return value;
 };
 
-const pathQuote = (path) => {
-  if (path.indexOf(" ") >= 0) {
-    if (path.indexOf("\"") >= 0) {
+const pathQuote = (fpath) => {
+  if (fpath.indexOf(' ') >= 0) {
+    if (fpath.indexOf('\"') >= 0) {
       if (process.platform === 'win32') {
-        path = '""' + path + '""';
+        fpath = '""' + fpath + '""';
       } else {
-        path = '"' + path.replace(/"/g, '\\"') + '"';
+        fpath = '"' + fpath.replace(/"/g, '\\"') + '"';
       }
     } else {
-      path = '"' + path + '"';
+      fpath = '"' + fpath + '"';
     }
   }
-  return path;
-}
+  return fpath;
+};
 
 export { uniquifySettings, activePath, getDefaultSettings, replace, pathQuote };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -93,7 +93,7 @@ const pathFix = (fpath) => {
     const pathSepPosixRegexp = new RegExp(pathSepPosix, 'g');
     fpath = fpath.replace(pathSepPosixRegexp, pathSepWin);
   } else {
-    const pathSepWinRegexp = new RegExp(pathSepWin, 'g');
+    const pathSepWinRegexp = new RegExp('\\' + pathSepWin, 'g'); // escape it.
     fpath = fpath.replace(pathSepWinRegexp, pathSepPosix);
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -84,4 +84,19 @@ const replace = (value = '', targetEnv) => {
   return value;
 };
 
-export { uniquifySettings, activePath, getDefaultSettings, replace };
+const pathQuote = (path) => {
+  if (path.indexOf(" ") >= 0) {
+    if (path.indexOf("\"") >= 0) {
+      if (process.platform === 'win32') {
+        path = '""' + path + '""';
+      } else {
+        path = '"' + path.replace(/"/g, '\\"') '"';
+      }
+    } else {
+      path = '"' + path + '"';
+    }
+  }
+  return path;
+}
+
+export { uniquifySettings, activePath, getDefaultSettings, replace, pathQuote };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -104,15 +104,14 @@ const cmdQuote = (args) => {
   const charsToProtect = /[ ()"]/g;
 
   // Replace all double quotes within each arg string with an escaped double quote.
-  return '"' + args.map(function (str) {
-    let protectedStr = str.replace(/"/g, '\\"');
-
+  return args.map(function (str) {
+    let protectedStr = str;
     if (charsToProtect.test(str)) {
-      protectedStr = protectedStr.replace(/\\"/g, '\\\\\\"');
-      protectedStr = '\\"' + protectedStr + '\\"';
+      protectedStr = protectedStr.replace(/"/g, '\\"');
+      protectedStr = '"' + protectedStr + '"';
     }
     return protectedStr;
-  }).join(' ') + '"';
+  }).join(' ');
 };
 
 export { uniquifySettings, activePath, getDefaultSettings, replace, pathFix, cmdQuote };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -84,9 +84,21 @@ const replace = (value = '', targetEnv) => {
   return value;
 };
 
-const pathQuote = (fpath) => {
-  const pathSep = require('path').sep;
-  if (fpath.indexOf(pathSep) >= 0) {
+const pathFix = (fpath) => {
+  const pathSepWin = require('path').win32.sep;
+  const pathSepPosix = require('path').posix.sep;
+
+  // Replace all occurrences of the other platform's path separator.
+  if (process.platform === 'win32') {
+    let pathSepPosixRegexp = new RegExp(pathSepPosix, 'g');
+    fpath = fpath.replace(pathSepPosixRegexp, pathSepWin);
+  } else {
+    let pathSepWinRegexp = new RegExp(pathSepWin, 'g');
+    fpath = fpath.replace(pathSepWinRegexp, pathSepPosix);
+  }
+
+  /*
+  if (fpath.indexOf(pathSepWin) >= 0 || fpath.indexOf(pathSepPosix) >= 0) {
     if (fpath.indexOf(' ') >= 0) {
       if (fpath.indexOf('"') >= 0) {
         if (process.platform === 'win32') {
@@ -99,7 +111,8 @@ const pathQuote = (fpath) => {
       }
     }
   }
+  */
   return fpath;
 };
 
-export { uniquifySettings, activePath, getDefaultSettings, replace, pathQuote };
+export { uniquifySettings, activePath, getDefaultSettings, replace, pathFix };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -85,15 +85,18 @@ const replace = (value = '', targetEnv) => {
 };
 
 const pathQuote = (fpath) => {
-  if (fpath.indexOf(' ') >= 0) {
-    if (fpath.indexOf('\"') >= 0) {
-      if (process.platform === 'win32') {
-        fpath = '""' + fpath + '""';
+  const pathSep = require("path").sep;
+  if (fpath.indexOf(pathSep) >= 0) {
+    if (fpath.indexOf(' ') >= 0) {
+      if (fpath.indexOf('"') >= 0) {
+        if (process.platform === 'win32') {
+          fpath = '""' + fpath + '""';
+        } else {
+          fpath = '"' + fpath.replace(/"/g, '\\"') + '"';
+        }
       } else {
-        fpath = '"' + fpath.replace(/"/g, '\\"') + '"';
+        fpath = '"' + fpath + '"';
       }
-    } else {
-      fpath = '"' + fpath + '"';
     }
   }
   return fpath;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -100,18 +100,4 @@ const pathFix = (fpath) => {
   return fpath;
 };
 
-const cmdQuote = (args) => {
-  const charsToProtect = /[ ()"]/g;
-
-  // Replace all double quotes within each arg string with an escaped double quote.
-  return args.map(function (str) {
-    let protectedStr = str;
-    if (charsToProtect.test(str)) {
-      protectedStr = protectedStr.replace(/"/g, '\\"');
-      protectedStr = '"' + protectedStr + '"';
-    }
-    return protectedStr;
-  }).join(' ');
-};
-
-export { uniquifySettings, activePath, getDefaultSettings, replace, pathFix, cmdQuote };
+export { uniquifySettings, activePath, getDefaultSettings, replace, pathFix };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -85,7 +85,7 @@ const replace = (value = '', targetEnv) => {
 };
 
 const pathQuote = (fpath) => {
-  const pathSep = require("path").sep;
+  const pathSep = require('path').sep;
   if (fpath.indexOf(pathSep) >= 0) {
     if (fpath.indexOf(' ') >= 0) {
       if (fpath.indexOf('"') >= 0) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -90,28 +90,13 @@ const pathFix = (fpath) => {
 
   // Replace all occurrences of the other platform's path separator.
   if (process.platform === 'win32') {
-    let pathSepPosixRegexp = new RegExp(pathSepPosix, 'g');
+    const pathSepPosixRegexp = new RegExp(pathSepPosix, 'g');
     fpath = fpath.replace(pathSepPosixRegexp, pathSepWin);
   } else {
-    let pathSepWinRegexp = new RegExp(pathSepWin, 'g');
+    const pathSepWinRegexp = new RegExp(pathSepWin, 'g');
     fpath = fpath.replace(pathSepWinRegexp, pathSepPosix);
   }
 
-  /*
-  if (fpath.indexOf(pathSepWin) >= 0 || fpath.indexOf(pathSepPosix) >= 0) {
-    if (fpath.indexOf(' ') >= 0) {
-      if (fpath.indexOf('"') >= 0) {
-        if (process.platform === 'win32') {
-          fpath = '""' + fpath + '""';
-        } else {
-          fpath = '"' + fpath.replace(/"/g, '\\"') + '"';
-        }
-      } else {
-        fpath = '"' + fpath + '"';
-      }
-    }
-  }
-  */
   return fpath;
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -90,7 +90,7 @@ const pathQuote = (path) => {
       if (process.platform === 'win32') {
         path = '""' + path + '""';
       } else {
-        path = '"' + path.replace(/"/g, '\\"') '"';
+        path = '"' + path.replace(/"/g, '\\"') + '"';
       }
     } else {
       path = '"' + path + '"';

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -107,7 +107,7 @@ const cmdQuote = (args) => {
   return '"' + args.map(function (str) {
     let protectedStr = str.replace(/"/g, '\\"');
 
-    if (charsToProtect.match(str)) {
+    if (charsToProtect.test(str)) {
       protectedStr = protectedStr.replace(/\\"/g, '\\\\\\"');
       protectedStr = '\\"' + protectedStr + '\\"';
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -100,4 +100,19 @@ const pathFix = (fpath) => {
   return fpath;
 };
 
-export { uniquifySettings, activePath, getDefaultSettings, replace, pathFix };
+const cmdQuote = (args) => {
+  const charsToProtect = /[ ()"]/g;
+
+  // Replace all double quotes within each arg string with an escaped double quote.
+  return '"' + args.map(function (str) {
+    let protectedStr = str.replace(/"/g, '\\"');
+
+    if (charsToProtect.match(str)) {
+      protectedStr = protectedStr.replace(/\\"/g, '\\\\\\"');
+      protectedStr = '\\"' + protectedStr + '\\"';
+    }
+    return protectedStr;
+  }).join(' ') + '"';
+};
+
+export { uniquifySettings, activePath, getDefaultSettings, replace, pathFix, cmdQuote };


### PR DESCRIPTION
Use a more elegant method of passing `exec` and its arguments to child_process.spawn()

Also:
- Convert Windows path delimiters to Unix path delimiters on Unix platforms.
- Convert Unix path delimiters to Windows path delimiters on Windows platforms.
