### PR TITLE
Allow consumeBuilder to accept arrays

### DIFF
--- a/create-provider.md
+++ b/create-provider.md
@@ -19,7 +19,7 @@ The package should integrate via the service API. This is typically done in `pac
 ```
 
 The `build`-package will then call `providingFunction` when activated and expects an
-ES6 class in return. The next section describes in detail how that class is
+ES6 class or an array of classes in return. The next section describes in detail how that class is
 expected to operate.
 
 ## The provider implementation

--- a/lib/build.js
+++ b/lib/build.js
@@ -302,11 +302,11 @@ export default {
   },
 
   consumeBuilder(builder) {
-    this.tools.push(builder);
+    if (Array.isArray(builder)) this.tools.push(...builder); else this.tools.push(builder);
     this.targetManager.setTools(this.tools);
     const Disposable = require('atom').Disposable;
     return new Disposable(() => {
-      this.tools = this.tools.filter(tool => tool !== builder);
+      this.tools = this.tools.filter(Array.isArray(builder) ? tool => builder.indexOf(tool) === -1 : tool => tool !== builder);
       this.targetManager.setTools(this.tools);
     });
   },


### PR DESCRIPTION
This adds the capability for a single package to provide multiple build providers.