### PR TITLE
Send SIGINT rather than SIGTERM

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Option            | Required       | Description
 `warningMatch`    | *[optional]*   | Like `errorMatch`, but is reported as just a warning
 `functionMatch`   | *[optional]*   | A (list of) javascript functions that return a list of match objects
 `keymap`          | *[optional]*   | A keymap string as defined by [`Atom`](https://atom.io/docs/latest/behind-atom-keymaps-in-depth). Pressing this key combination will trigger the target. Examples: `ctrl-alt-k` or `cmd-U`.
+`killSignals`     | *[optional]*   | An array of signals. The signals will be sent, one after each time `Escape` is pressed until the process has been terminated. The default value is `SIGINT` -> `SIGTERM` -> `SIGKILL`. The only signal which is guaranteed to terminate the process is `SIGKILL` so it is recommended to include that in the list.
 `atomCommandName` | *[optional]*   | Command name to register which should be on the form of `namespace:command`. Read more about [Atom CommandRegistry](https://atom.io/docs/api/v1.4.1/CommandRegistry). The command will be available in the command palette and can be trigger from there. If this is returned by a build provider, the command can programatically be triggered by [dispatching](https://atom.io/docs/api/v1.4.1/CommandRegistry#instance-dispatch).
 `targets`         | *[optional]*   | Additional targets which can be used to build variations of your project.
 `preBuild`        | *[optional]*   | **JS only**. A function which will be called *before* executing `cmd`. No arguments. `this` will be the build configuration.

--- a/lib/atom-build.js
+++ b/lib/atom-build.js
@@ -33,7 +33,8 @@ function createBuildConfig(build, name) {
     functionMatch: build.functionMatch,
     warningMatch: build.warningMatch,
     atomCommandName: build.atomCommandName,
-    keymap: build.keymap
+    keymap: build.keymap,
+    killSignals: build.killSignals
   };
 
   if (typeof build.postBuild === 'function') {

--- a/lib/build-view.js
+++ b/lib/build-view.js
@@ -9,7 +9,7 @@ export default class BuildView extends View {
   }
 
   static initialHeadingText() {
-    return '¯\\_(ツ)_/¯';
+    return 'Atom Build';
   }
 
   static content() {
@@ -23,7 +23,7 @@ export default class BuildView extends View {
             this.span({ class: 'build-timer', outlet: 'buildTimer' }, this.initialTimerText());
           });
         });
-        this.div({ class: 'heading-text', outlet: 'heading' }, this.initialHeadingText());
+        this.div({ class: 'icon heading-text', outlet: 'heading' }, this.initialHeadingText());
       });
 
       this.div({ class: 'output panel-body', outlet: 'output' });
@@ -32,8 +32,8 @@ export default class BuildView extends View {
   }
 
   constructor(...args) {
-    const Terminal = require('term.js');
     super(...args);
+    const Terminal = require('term.js');
     this.starttime = new Date();
     this.terminal = new Terminal({
       cursorBlink: false,
@@ -146,7 +146,7 @@ export default class BuildView extends View {
     const w = o[0].getBoundingClientRect().width;
     const h = o[0].getBoundingClientRect().height;
     o.remove();
-    return { w: w, h: h};
+    return { w, h };
   }
 
   resizeTerminal() {
@@ -316,6 +316,7 @@ export default class BuildView extends View {
   }
 
   buildAbortInitiated() {
+    this.heading.addClass('icon-stop');
   }
 
   buildAborted() {
@@ -325,6 +326,7 @@ export default class BuildView extends View {
   finalizeBuild(success) {
     this.title.addClass(success ? 'success' : 'error');
     this.panelHeading.addClass(success ? 'success' : 'error');
+    this.heading.removeClass('icon-stop');
     clearTimeout(this.titleTimer);
   }
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -237,7 +237,7 @@ export default {
     });
 
     try {
-      require('tree-kill')(this.child.pid, this.child.killed ? 'SIGKILL' : 'SIGTERM');
+      require('tree-kill')(this.child.pid, this.child.killed ? 'SIGKILL' : 'SIGINT');
     } catch (e) {
       /* Something may have happened to the child (e.g. terminated by itself). Ignore this. */
     }

--- a/lib/build.js
+++ b/lib/build.js
@@ -167,7 +167,7 @@ export default {
       this.child.stderr.on('data', d => (stderr += d));
       this.child.stdout.pipe(this.buildView.terminal);
       this.child.stderr.pipe(this.buildView.terminal);
-      this.child.killSignals = target.killSignals.slice() || [ 'SIGINT', 'SIGTERM', 'SIGKILL' ];
+      this.child.killSignals = (target.killSignals || [ 'SIGINT', 'SIGTERM', 'SIGKILL' ]).slice();
 
       this.child.on('error', (err) => {
         this.buildView.terminal.write((target.sh ? 'Unable to execute with shell: ' : 'Unable to execute: ') + exec + '\n');

--- a/lib/build.js
+++ b/lib/build.js
@@ -167,7 +167,7 @@ export default {
       this.child.stderr.on('data', d => (stderr += d));
       this.child.stdout.pipe(this.buildView.terminal);
       this.child.stderr.pipe(this.buildView.terminal);
-      this.child.killSignals = [ 'SIGINT', 'SIGTERM', 'SIGKILL' ];
+      this.child.killSignals = target.killSignals.slice() || [ 'SIGINT', 'SIGTERM', 'SIGKILL' ];
 
       this.child.on('error', (err) => {
         this.buildView.terminal.write((target.sh ? 'Unable to execute with shell: ' : 'Unable to execute: ') + exec + '\n');

--- a/lib/build.js
+++ b/lib/build.js
@@ -167,6 +167,7 @@ export default {
       this.child.stderr.on('data', d => (stderr += d));
       this.child.stdout.pipe(this.buildView.terminal);
       this.child.stderr.pipe(this.buildView.terminal);
+      this.child.killSignals = [ 'SIGINT', 'SIGTERM', 'SIGKILL' ];
 
       this.child.on('error', (err) => {
         this.buildView.terminal.write((target.sh ? 'Unable to execute with shell: ' : 'Unable to execute: ') + exec + '\n');
@@ -214,6 +215,9 @@ export default {
             }
             require('./google-analytics').sendEvent('build', 'failed');
           }
+
+          this.nextBuild && this.nextBuild();
+          this.nextBuild = null;
         });
       });
     }).catch((err) => {
@@ -230,27 +234,38 @@ export default {
     });
   },
 
-  abort(cb) {
-    this.child.on('exit', () => {
-      this.child = null;
-      cb && cb();
-    });
-
+  sendNextSignal() {
     try {
-      require('tree-kill')(this.child.pid, this.child.killed ? 'SIGKILL' : 'SIGINT');
+      const signal = this.child.killSignals.shift();
+      require('tree-kill')(this.child.pid, signal);
     } catch (e) {
       /* Something may have happened to the child (e.g. terminated by itself). Ignore this. */
     }
+  },
 
-    this.child.killed = true;
+  abort(cb) {
+    if (!this.child.killed) {
+      this.buildView.buildAbortInitiated();
+      this.child.killed = true;
+      this.child.on('exit', () => {
+        this.child = null;
+        cb && cb();
+      });
+    }
+
+    this.sendNextSignal();
   },
 
   build(source, event) {
     clearTimeout(this.finishedTimer);
 
     this.doSaveConfirm(this.unsavedTextEditors(), () => {
-      const next = this.startNewBuild.bind(this, source, event ? event.type : null);
-      this.child ? this.abort(next) : next();
+      const nextBuild = this.startNewBuild.bind(this, source, event ? event.type : null);
+      if (this.child) {
+        this.nextBuild = nextBuild;
+        return this.abort();
+      }
+      return nextBuild();
     });
   },
 
@@ -281,11 +296,9 @@ export default {
   },
 
   stop() {
+    this.nextBuild = null;
     clearTimeout(this.finishedTimer);
     if (this.child) {
-      if (!this.child.killed) {
-        this.buildView.buildAbortInitiated();
-      }
       this.abort(() => {
         this.buildView.buildAborted();
         this.statusBarView && this.statusBarView.buildAborted();

--- a/spec/build-error-match-spec.js
+++ b/spec/build-error-match-spec.js
@@ -697,6 +697,7 @@ describe('Error Match', () => {
       runs(() => {
         expect(workspaceElement.querySelector('.build')).toExist();
         atom.commands.dispatch(workspaceElement, 'build:stop');
+        atom.commands.dispatch(workspaceElement, 'build:stop');
       });
 
       waitsFor(() => {

--- a/spec/build-spec.js
+++ b/spec/build-spec.js
@@ -116,6 +116,7 @@ describe('Build', () => {
         expect(workspaceElement.querySelector('.build')).toExist();
         expect(workspaceElement.querySelector('.terminal').terminal.getContent()).toMatch(/Building, this will take some time.../);
         atom.commands.dispatch(workspaceElement, 'build:stop');
+        atom.commands.dispatch(workspaceElement, 'build:stop');
       });
 
       waitsFor(() => {

--- a/spec/linter-intergration-spec.js
+++ b/spec/linter-intergration-spec.js
@@ -1,5 +1,6 @@
 'use babel';
 
+import os from 'os';
 import fs from 'fs-extra';
 import temp from 'temp';
 import specHelpers from 'atom-build-spec-helpers';
@@ -10,10 +11,13 @@ describe('Linter Integration', () => {
   let workspaceElement = null;
   let dummyPackage = null;
   const join = require('path').join;
+  const originalHomedirFn = os.homedir;
 
   temp.track();
 
   beforeEach(() => {
+    const createdHomeDir = temp.mkdirSync('atom-build-spec-home');
+    os.homedir = () => createdHomeDir;
     directory = fs.realpathSync(temp.mkdirSync({ prefix: 'atom-build-spec-' }));
     atom.project.setPaths([ directory ]);
 
@@ -42,6 +46,7 @@ describe('Linter Integration', () => {
 
   afterEach(() => {
     fs.removeSync(directory);
+    os.homedir = originalHomedirFn;
   });
 
   describe('when error matching and linter is activated', () => {

--- a/styles/build.less
+++ b/styles/build.less
@@ -31,6 +31,12 @@
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
+
+      &::before {
+        margin-right: 5px;
+        color: @text-color-error;
+        animation: flash linear infinite 1.0s;
+      }
     }
 
     .control-container {


### PR DESCRIPTION
While SIGTERM may be the "correct" choice from a documentation
standpoint, SIGINT is more widely used. Most applications are
designed to run in a terminal and most (all?) send SIGINT
when issuing ^C.

This PR simulates this behavior from atom-build.