### PR TITLE
Linter's html field support

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,10 @@ Instead of adding squiggly lines at the location given by the `file`, `line` and
 `col` fields, a link is added to the popup message, so you can conveniently jump
 to the location given in the trace.
 
+One more feature provided by `functionMatch` is the ability to use HTML in
+the message text by setting `html_message` instead of `message`. If both
+`html_message` and `message` are set, the latter takes priority.
+
 <a name="custom-build-config"></a>
 #### Configuration options
 

--- a/lib/linter-integration.js
+++ b/lib/linter-integration.js
@@ -32,14 +32,14 @@ class Linter {
     this.linter.setMessages(messages.map(match => ({
       type: match.type || 'Error',
       text: !match.message && !match.html_message ? 'Error from build' : match.message,
-      html: match.html_message,
+      html: match.message ? undefined : match.html_message,
       filePath: normalizePath(match.file),
       severity: typeToSeverity(match.type),
       range: extractRange(match),
       trace: match.trace && match.trace.map(trace => ({
         type: trace.type || 'Trace',
         text: !trace.message && !trace.html_message ? 'Trace in build' : trace.message,
-        html: trace.html_message,
+        html: trace.message ? undefined : trace.html_message,
         filePath: trace.file && normalizePath(trace.file),
         severity: typeToSeverity(trace.type) || 'info',
         range: extractRange(trace)

--- a/lib/linter-integration.js
+++ b/lib/linter-integration.js
@@ -31,7 +31,8 @@ class Linter {
     }
     this.linter.setMessages(messages.map(match => ({
       type: match.type || 'Error',
-      text: match.message || 'Error from build',
+      text: !match.message && !match.html_message ? 'Error from build' : match.message,
+      html: match.html_message,
       filePath: normalizePath(match.file),
       severity: typeToSeverity(match.type),
       range: extractRange(match),

--- a/lib/linter-integration.js
+++ b/lib/linter-integration.js
@@ -38,7 +38,8 @@ class Linter {
       range: extractRange(match),
       trace: match.trace && match.trace.map(trace => ({
         type: trace.type || 'Trace',
-        text: trace.message || 'Trace in build',
+        text: !trace.message && !trace.html_message ? 'Trace in build' : trace.message,
+        html: trace.html_message,
         filePath: trace.file && normalizePath(trace.file),
         severity: typeToSeverity(trace.type) || 'info',
         range: extractRange(trace)

--- a/spec/fixture/.atom-build.match-function-html.js
+++ b/spec/fixture/.atom-build.match-function-html.js
@@ -1,0 +1,16 @@
+module.exports = {
+  cmd: 'echo',
+  args: [ 'doughnut' ],
+  name: 'from js',
+  sh: true,
+  functionMatch: function (terminal_output) {
+    return [
+      {
+        file: '.atom-build.js',
+        line: '5',
+        type: 'Warning',
+        html_message: 'mildly <b>bad</b> things',
+      }
+    ];
+  }
+};

--- a/spec/fixture/.atom-build.match-function-message-and-html.js
+++ b/spec/fixture/.atom-build.match-function-message-and-html.js
@@ -1,0 +1,17 @@
+module.exports = {
+  cmd: 'echo',
+  args: [ 'pancake' ],
+  name: 'from js',
+  sh: true,
+  functionMatch: function (terminal_output) {
+    return [
+      {
+        file: '.atom-build.js',
+        line: '5',
+        type: 'Warning',
+        message: 'something happened in plain text',
+        html_message: 'something happened in <b>html</b>',
+      }
+    ];
+  }
+};

--- a/spec/fixture/.atom-build.match-function-trace-html.js
+++ b/spec/fixture/.atom-build.match-function-trace-html.js
@@ -1,0 +1,21 @@
+module.exports = {
+  cmd: 'echo',
+  args: [ 'cake' ],
+  name: 'from js',
+  sh: true,
+  functionMatch: function (terminal_output) {
+    return [
+      {
+        file: '.atom-build.js',
+        line: '6',
+        type: 'Error',
+        trace: [
+          {
+            type: 'Explanation',
+            html_message: 'insert <i>great</i> explanation here',
+          }
+        ],
+      }
+    ];
+  }
+};

--- a/spec/fixture/.atom-build.match-function-trace-message-and-html.js
+++ b/spec/fixture/.atom-build.match-function-trace-message-and-html.js
@@ -1,0 +1,22 @@
+module.exports = {
+  cmd: 'echo',
+  args: [ 'pancake' ],
+  name: 'from js',
+  sh: true,
+  functionMatch: function (terminal_output) {
+    return [
+      {
+        file: '.atom-build.js',
+        line: '6',
+        type: 'Error',
+        trace: [
+          {
+            type: 'Explanation',
+            message: 'insert plain text explanation here',
+            html_message: 'insert <i>html</i> explanation here',
+          }
+        ],
+      }
+    ];
+  }
+};

--- a/spec/linter-intergration-spec.js
+++ b/spec/linter-intergration-spec.js
@@ -68,6 +68,7 @@ describe('Linter Integration', () => {
             filePath: join(directory, '.atom-build.json'),
             range: [ [2, 7], [2, 7] ],
             text: 'Error from build',
+            html: undefined,
             type: 'Error',
             severity: 'error',
             trace: undefined
@@ -76,6 +77,7 @@ describe('Linter Integration', () => {
             filePath: join(directory, '.atom-build.json'),
             range: [ [1, 4], [1, 4] ],
             text: 'Error from build',
+            html: undefined,
             type: 'Error',
             severity: 'error',
             trace: undefined
@@ -102,6 +104,7 @@ describe('Linter Integration', () => {
             filePath: join(directory, '.atom-build.json'),
             range: [ [2, 7], [2, 7] ],
             text: 'very bad things',
+            html: undefined,
             type: 'Error',
             severity: 'error',
             trace: undefined
@@ -128,6 +131,7 @@ describe('Linter Integration', () => {
             filePath: join(directory, '.atom-build.js'),
             range: [ [4, 0], [4, 0] ],
             text: 'mildly bad things',
+            html: undefined,
             type: 'Warning',
             severity: 'warning',
             trace: undefined
@@ -154,11 +158,13 @@ describe('Linter Integration', () => {
             filePath: join(directory, '.atom-build.js'),
             range: [ [5, 0], [5, 0] ],
             text: 'Error from build',
+            html: undefined,
             type: 'Error',
             severity: 'error',
             trace: [
               {
                 text: 'insert great explanation here',
+                html: undefined,
                 severity: 'info',
                 type: 'Explanation',
                 range: [ [0, 0], [0, 0]],
@@ -188,6 +194,7 @@ describe('Linter Integration', () => {
             filePath: join(directory, '.atom-build.json'),
             range: [ [2, 7], [2, 7] ],
             text: 'very bad things',
+            html: undefined,
             type: 'Error',
             severity: 'error',
             trace: undefined
@@ -212,5 +219,69 @@ describe('Linter Integration', () => {
         expect(dummyPackage.getLinter().messages.length).toEqual(0);
       });
     });
+
+    it('should leave text undefined if html is set', () => {
+      expect(dummyPackage.hasRegistered()).toEqual(true);
+      fs.writeFileSync(join(directory, '.atom-build.js'), fs.readFileSync(join(__dirname, 'fixture', '.atom-build.match-function-html.js')));
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
+      waitsFor(() => {
+        return workspaceElement.querySelector('.build .title') &&
+          workspaceElement.querySelector('.build .title').classList.contains('success');
+      });
+
+      runs(() => {
+        const linter = dummyPackage.getLinter();
+        expect(linter.messages).toEqual([
+          {
+            filePath: join(directory, '.atom-build.js'),
+            range: [ [4, 0], [4, 0] ],
+            text: undefined,
+            html: 'mildly <b>bad</b> things',
+            type: 'Warning',
+            severity: 'warning',
+            trace: undefined
+          }
+        ]);
+      });
+    });
+
+    it('should leave text undefined if html is set in traces', () => {
+      expect(dummyPackage.hasRegistered()).toEqual(true);
+      fs.writeFileSync(join(directory, '.atom-build.js'), fs.readFileSync(join(__dirname, 'fixture', '.atom-build.match-function-trace-html.js')));
+
+      runs(() => atom.commands.dispatch(workspaceElement, 'build:trigger'));
+
+      waitsFor(() => {
+        return workspaceElement.querySelector('.build .title') &&
+          workspaceElement.querySelector('.build .title').classList.contains('error');
+      });
+
+      runs(() => {
+        const linter = dummyPackage.getLinter();
+        expect(linter.messages).toEqual([
+          {
+            filePath: join(directory, '.atom-build.js'),
+            range: [ [5, 0], [5, 0] ],
+            text: 'Error from build',
+            html: undefined,
+            type: 'Error',
+            severity: 'error',
+            trace: [
+              {
+                text: undefined,
+                html: 'insert <i>great</i> explanation here',
+                severity: 'info',
+                type: 'Explanation',
+                range: [ [0, 0], [0, 0]],
+                filePath: undefined
+              }
+            ]
+          }
+        ]);
+      });
+    });
+
   });
 });

--- a/spec/linter-intergration-spec.js
+++ b/spec/linter-intergration-spec.js
@@ -282,6 +282,5 @@ describe('Linter Integration', () => {
         ]);
       });
     });
-
   });
 });


### PR DESCRIPTION
Added support for the Linter's message `html` field via `html_message`.

fixes #428 