### PR TITLE
added: postBuild is now also passed stdout and stderr, allowing custom handling of build output

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ Option            | Required       | Description
 `atomCommandName` | *[optional]*   | Command name to register which should be on the form of `namespace:command`. Read more about [Atom CommandRegistry](https://atom.io/docs/api/v1.4.1/CommandRegistry). The command will be available in the command palette and can be trigger from there. If this is returned by a build provider, the command can programatically be triggered by [dispatching](https://atom.io/docs/api/v1.4.1/CommandRegistry#instance-dispatch).
 `targets`         | *[optional]*   | Additional targets which can be used to build variations of your project.
 `preBuild`        | *[optional]*   | **JS only**. A function which will be called *before* executing `cmd`. No arguments. `this` will be the build configuration.
-`postBuild`       | *[optional]*   | **JS only**. A function which will be called *after* executing `cmd`. A single argument `bool buildOutcome` indicating outcome of the running `cmd`. `this` will be the build configuration.
+`postBuild`       | *[optional]*   | **JS only**. A function which will be called *after* executing `cmd`. It will be passed 3 arguments: `bool buildOutcome` indicating outcome of the running `cmd`, `string stdout` containing the contents of `stdout`, and `string stderr` containing the contents of `stderr`. `this` will be the build configuration.
 
 #### Replacements
 

--- a/lib/build.js
+++ b/lib/build.js
@@ -198,7 +198,7 @@ export default {
         }
 
         this.buildView.setHeading('Running postBuild...');
-        return Promise.resolve(target.postBuild ? target.postBuild(success) : null).then(() => {
+        return Promise.resolve(target.postBuild ? target.postBuild(success, stdout, stderr) : null).then(() => {
           this.buildView.setHeading(buildTitle);
 
           this.busyRegistry && this.busyRegistry.end(`build.${target.name}`, success);


### PR DESCRIPTION
See #463 