### PR TITLE
added: non-file specific errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ the message text by setting `html_message` instead of `message`. If both
 
 Option            | Required       | Description
 ------------------|----------------|-----------------------
-`cmd`             | *[required]* | The executable command
+`cmd`             | **[required]** | The executable command
 `name`            | *[optional]*   | The name of the target. Viewed in the targets list (toggled by `build:select-active-target`).
 `args`            | *[optional]*   | An array of arguments for the command
 `sh`              | *[optional]*   | If `true`, the combined command and arguments will be passed to `/bin/sh`. Default `true`.

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ the message text by setting `html_message` instead of `message`. If both
 
 Option            | Required       | Description
 ------------------|----------------|-----------------------
-`cmd`             | **[required]** | The executable command
+`cmd`             | *[required]* | The executable command
 `name`            | *[optional]*   | The name of the target. Viewed in the targets list (toggled by `build:select-active-target`).
 `args`            | *[optional]*   | An array of arguments for the command
 `sh`              | *[optional]*   | If `true`, the combined command and arguments will be passed to `/bin/sh`. Default `true`.
@@ -262,7 +262,7 @@ and has the syntax for named groups: `(?<name> RE )` where `name` would be the n
 matched by the regular expression `RE`.
 
 The following named groups can be matched from the output:
-  * `file` - **[required]** the file to open. May be relative `cwd` or absolute. `(?<file> RE)`.
+  * `file` - *[optional]* the file the error occurs in. May be relative `cwd` or absolute. `(?<file> RE)`.
   * `line` - *[optional]* the line the error starts on. `(?<line> RE)`.
   * `col` - *[optional]* the column the error starts on. `(?<col> RE)`.
   * `line_end` - *[optional]* the line the error ends on. `(?<line_end> RE)`.
@@ -279,6 +279,8 @@ Atom Linter integration discussed in the next section.
 
 Often, the first error is the most interesting since other errors tend to be secondary faults caused by that first one.
 To jump to the first error you can use <kbd>Cmd</kbd> <kbd>Alt</kbd> <kbd>H</kbd> (OS X) or <kbd>Shift</kbd> <kbd>F4</kbd> (Linux/Windows) at any point to go to the first error.
+
+For errors that do not have a `file` specified - they will not be marked in the source or be accessible via keyboard shortcuts, but will instead be shown in a single popup error notification.
 
 ### Error matching and Atom Linter
 

--- a/lib/linter-integration.js
+++ b/lib/linter-integration.js
@@ -29,7 +29,7 @@ class Linter {
         default: return null;
       }
     }
-    this.linter.setMessages(messages.map(match => ({
+    this.linter.setMessages(messages.filter(match => {return !!match.file}).map(match => ({
       type: match.type || 'Error',
       text: !match.message && !match.html_message ? 'Error from build' : match.message,
       html: match.message ? undefined : match.html_message,
@@ -45,6 +45,37 @@ class Linter {
         range: extractRange(trace)
       }))
     })));
+    var globalWarnings = [];
+    var globalErrors = [];
+    for (var match of messages) {
+      if (!match.file && match.message) {
+        if (match.type == 'Warning') {
+          globalWarnings.push(match.message);
+        } else {
+          globalErrors.push(match.message);
+        }
+      }
+    }
+    if (globalErrors.length > 1) {
+      atom.notifications.addError(globalErrors.length+' errors from build', {
+        detail: globalErrors.join('\n'),
+        dismissable: true
+      });
+    } else if (globalErrors.length == 1) {
+      atom.notifications.addError(globalErrors[0], {
+        dismissable: true
+      });
+    }
+    if (globalWarnings.length > 1) {
+      atom.notifications.addError(globalWarnings.length+' warnings from build', {
+        detail: globalWarnings.join('\n'),
+        dismissable: true
+      });
+    } else if (globalWarnings.length == 1) {
+      atom.notifications.addError(globalWarnings[0], {
+        dismissable: true
+      });
+    }
   }
 }
 


### PR DESCRIPTION
`errorMatch` and `warningMatch` may now catching a the `file`.

These errors will be grouped together, and displayed via an atom error notification popup (as Linter does not currently support displaying errors without file locations).

see #463 