### PR TITLE
Add class to build target modal

### DIFF
--- a/lib/targets-view.js
+++ b/lib/targets-view.js
@@ -11,6 +11,7 @@ export default class TargetsView extends SelectListView {
 
   initialize() {
     super.initialize(...arguments);
+    this.addClass('build-target');
     this.list.addClass('mark-active');
   }
 


### PR DESCRIPTION
Add `build-target` to class list of the build target list view, to distinguish it from other modals for styling purposes.