### PR TITLE
Allow copying text from build output

### DIFF
--- a/keymaps/build.json
+++ b/keymaps/build.json
@@ -13,6 +13,12 @@
     "ctrl-alt-h": "build:error-match-first",
     "ctrl-alt-t": "build:select-active-target"
   },
+  "body.platform-darwin .build .output": {
+    "cmd-c": "core:copy"
+  },
+  "body.platform-linux .build .output, body.platform-win32 .build .output": {
+    "ctrl-c": "core:copy"
+  },
   "atom-workspace, atom-text-editor": {
     "f9": "build:trigger",
     "f8": "build:toggle-panel",


### PR DESCRIPTION
Copying text out of the build output div isn't working right now (tested with Atom 1.10.2 on Mac OS X). Since no `user-select` override is used, I guess it must be because of the way `core:copy` is mapped to keys by Atom's default keymaps – Cmd+C doesn't trigger `core:copy` when selecting text in the output console. This change enables copying text.