### PR TITLE
Fix issue with incorrect path for text editor

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -32,7 +32,7 @@ const activePath = () => {
   return atom.project.getPaths().sort((a, b) => (b.length - a.length)).find(p => {
     try {
       const realpath = fs.realpathSync(p);
-      return textEditor.getPath().substr(0, realpath.length) === realpath;
+      return fs.realpathSync(textEditor.getPath()).substr(0, realpath.length) === realpath;
     } catch (err) {
       /* Path no longer available. Possible network volume has gone down */
       return false;


### PR DESCRIPTION
Atom >= 1.13 doesn't return a real path for `textEditor.getPath()`. In this case, affected projects will not be available for "build".

For example, project is located in `/private/tmp/myproject`
* `fs.realpathSync('/private/tmp/myproject') === '/private/tmp/myproject'`
* `textEditor.getPath() === '/tmp/myproject'`
* `fs.realpathSync(textEditor.getPath()) === '/private/tmp/myproject'`