### PR TITLE
Fix #484, #447

### DIFF
--- a/lib/target-manager.js
+++ b/lib/target-manager.js
@@ -122,6 +122,8 @@ class TargetManager extends EventEmitter {
 
         pathTarget.targets = settings;
         pathTarget.loading = false;
+
+        return pathTarget
       }).catch(err => {
         atom.notifications.addError('Ooops. Something went wrong.', {
           detail: err.message,
@@ -131,12 +133,18 @@ class TargetManager extends EventEmitter {
       });
     });
 
-    return Promise.all(pathPromises).then(entries => {
-      this.fillTargets(require('./utils').activePath());
+    return Promise.all(pathPromises).then(pathTargets => {
+
+      if (this.targetsView) {
+        const activePath = require('./utils').activePath();
+        const pathTarget = pathTargets.find(pt => pt.path == activePath)
+        this.targetsView.setItems(pathTarget.targets.map(t => t.name))
+      }
+
       this.emit('refresh-complete');
       this.busyRegistry && this.busyRegistry.end('build.refresh-targets');
 
-      if (entries.length === 0) {
+      if (pathTargets.length === 0) {
         return;
       }
 

--- a/lib/target-manager.js
+++ b/lib/target-manager.js
@@ -123,7 +123,7 @@ class TargetManager extends EventEmitter {
         pathTarget.targets = settings;
         pathTarget.loading = false;
 
-        return pathTarget
+        return pathTarget;
       }).catch(err => {
         atom.notifications.addError('Ooops. Something went wrong.', {
           detail: err.message,
@@ -134,11 +134,10 @@ class TargetManager extends EventEmitter {
     });
 
     return Promise.all(pathPromises).then(pathTargets => {
-
       if (this.targetsView) {
         const activePath = require('./utils').activePath();
-        const pathTarget = pathTargets.find(pt => pt.path == activePath)
-        this.targetsView.setItems(pathTarget.targets.map(t => t.name))
+        const pathTarget = pathTargets.find(pt => pt.path === activePath);
+        this.targetsView.setItems(pathTarget.targets.map(t => t.name));
       }
 
       this.emit('refresh-complete');


### PR DESCRIPTION
In TargetManager, getTargets, and by extension fillTargets, has an
implicit requirement that pathTarget.targets is not empty. If it is we
re-call refreshTargets which would end up with infinite recursion. We
don't actually need to call fillTargets as we already know which targets
are available, we can just set them ourselves