### PR TITLE
Fix #484, #447

### DIFF
--- a/lib/target-manager.js
+++ b/lib/target-manager.js
@@ -122,6 +122,8 @@ class TargetManager extends EventEmitter {
 
         pathTarget.targets = settings;
         pathTarget.loading = false;
+
+        return pathTarget;
       }).catch(err => {
         atom.notifications.addError('Ooops. Something went wrong.', {
           detail: err.message,
@@ -131,12 +133,19 @@ class TargetManager extends EventEmitter {
       });
     });
 
-    return Promise.all(pathPromises).then(entries => {
-      this.fillTargets(require('./utils').activePath());
+    return Promise.all(pathPromises).then(pathTargets => {
+      if (this.targetsView) {
+        const activePath = require('./utils').activePath();
+        const activeTarget = this.getActiveTarget(activePath);
+        activeTarget && this.targetsView.setActiveTarget(activeTarget.name);
+        const pathTarget = pathTargets.find(pt => pt.path === activePath);
+        this.targetsView.setItems(pathTarget.targets.map(t => t.name));
+      }
+
       this.emit('refresh-complete');
       this.busyRegistry && this.busyRegistry.end('build.refresh-targets');
 
-      if (entries.length === 0) {
+      if (pathTargets.length === 0) {
         return;
       }
 


### PR DESCRIPTION
In TargetManager, getTargets, and by extension fillTargets, has an
implicit requirement that pathTarget.targets is not empty. If it is we
re-call refreshTargets which would end up with infinite recursion. We
have enough information to retrace the steps fillTargets currently takes so
we can just set them ourselves.

There are three failing tests with my current implementation, however these three tests were failing before I made any changes.