### PR TITLE
Fix spelling: succeding -> succeeding

### DIFF
--- a/spec/build-hooks-spec.js
+++ b/spec/build-hooks-spec.js
@@ -7,7 +7,7 @@ import specHelpers from 'atom-build-spec-helpers';
 describe('Hooks', () => {
   let directory = null;
   let workspaceElement = null;
-  const succedingCommandName = 'build:hook-test:succeding';
+  const succeedingCommandName = 'build:hook-test:succeeding';
   const failingCommandName = 'build:hook-test:failing';
   const dummyPackageName = 'atom-build-hooks-dummy-package';
   const dummyPackagePath = __dirname + '/fixture/' + dummyPackageName;
@@ -51,7 +51,7 @@ describe('Hooks', () => {
       pkg = atom.packages.getActivePackage(dummyPackageName).mainModule;
       spyOn(pkg.hooks, 'preBuild');
 
-      atom.commands.dispatch(workspaceElement, succedingCommandName);
+      atom.commands.dispatch(workspaceElement, succeedingCommandName);
     });
 
     waitsFor(() => {
@@ -71,7 +71,7 @@ describe('Hooks', () => {
         pkg = atom.packages.getActivePackage(dummyPackageName).mainModule;
         spyOn(pkg.hooks, 'postBuild');
 
-        atom.commands.dispatch(workspaceElement, succedingCommandName);
+        atom.commands.dispatch(workspaceElement, succeedingCommandName);
       });
 
       waitsFor(() => {

--- a/spec/fixture/atom-build-hooks-dummy-package/main.js
+++ b/spec/fixture/atom-build-hooks-dummy-package/main.js
@@ -19,7 +19,7 @@ class Builder {
       {
         exec: 'exit',
         args: ['0'],
-        atomCommandName: 'build:hook-test:succeding',
+        atomCommandName: 'build:hook-test:succeeding',
         preBuild: () => hooks.preBuild(),
         postBuild: (success) => hooks.postBuild(success)
       },


### PR DESCRIPTION
I searched through several build providers to see if this would break anything, and I haven't yet found any uses of this hook, but this needs more extensive searching to be sure.