### PR TITLE
Use `busy-signal` over `busy`

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -124,7 +124,7 @@ export default {
       }
 
       this.statusBarView && this.statusBarView.buildStarted();
-      this.busyRegistry && this.busyRegistry.begin(`build.${target.name}`, `${target.name}`);
+      this.busyProvider && this.busyProvider.add(`Build: ${target.name}`);
       this.buildView.buildStarted();
       this.buildView.setHeading('Running preBuild...');
 
@@ -203,7 +203,7 @@ export default {
         return Promise.resolve(target.postBuild ? target.postBuild(success, stdout, stderr) : null).then(() => {
           this.buildView.setHeading(buildTitle);
 
-          this.busyRegistry && this.busyRegistry.end(`build.${target.name}`, success);
+          this.busyProvider && this.busyProvider.remove(`Build: ${target.name}`, success);
           this.buildView.buildFinished(success);
           this.statusBarView && this.statusBarView.setBuildSuccess(success);
           if (success) {
@@ -333,8 +333,8 @@ export default {
     this.statusBarView.attach();
   },
 
-  consumeBusy(registry) {
-    this.busyRegistry = registry;
-    this.targetManager.setBusyRegistry(registry);
+  consumeBusySignal(registry) {
+    this.busyProvider = registry.create();
+    this.targetManager.setBusyProvider(this.busyProvider);
   }
 };

--- a/lib/target-manager.js
+++ b/lib/target-manager.js
@@ -23,8 +23,8 @@ class TargetManager extends EventEmitter {
     atom.commands.add('atom-workspace', 'build:select-active-target', () => this.selectActiveTarget());
   }
 
-  setBusyRegistry(registry) {
-    this.busyRegistry = registry;
+  setBusyProvider(busyProvider) {
+    this.busyProvider = busyProvider;
   }
 
   _defaultPathTarget(path) {
@@ -54,7 +54,7 @@ class TargetManager extends EventEmitter {
   refreshTargets(refreshPaths) {
     refreshPaths = refreshPaths || atom.project.getPaths();
 
-    this.busyRegistry && this.busyRegistry.begin('build.refresh-targets', `Refreshing targets for ${refreshPaths.join(',')}`);
+    this.busyProvider && this.busyProvider.add(`Refreshing targets for ${refreshPaths.join(',')}`);
     const pathPromises = refreshPaths.map((path) => {
       const pathTarget = this.pathTargets.find(pt => pt.path === path);
       pathTarget.loading = true;
@@ -136,7 +136,7 @@ class TargetManager extends EventEmitter {
     return Promise.all(pathPromises).then(pathTargets => {
       this.fillTargets(require('./utils').activePath(), false);
       this.emit('refresh-complete');
-      this.busyRegistry && this.busyRegistry.end('build.refresh-targets');
+      this.busyProvider && this.busyProvider.remove(`Refreshing targets for ${refreshPaths.join(',')}`);
 
       if (pathTargets.length === 0) {
         return;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "temp": "^0.8.1"
   },
   "package-deps": [
-    "busy"
+    "busy-signal"
   ],
   "consumedServices": {
     "builder": {
@@ -41,9 +41,9 @@
         "^1.0.0": "consumeStatusBar"
       }
     },
-    "busy": {
+    "busy-signal": {
       "versions": {
-        "^1.0.0": "consumeBusy"
+        "^1.0.0": "consumeBusySignal"
       }
     },
     "linter-indie": {


### PR DESCRIPTION
Busy Signal is most widely adopted and it doesn't make sense
to have 2 packages which does the same thing. Get with the program
and use `busy-signal`.

Fixes #528