### PR TITLE
close stdin in spawned child processes

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -151,13 +151,13 @@ export default {
         this.child = require('child_process').spawn(
           shCmd,
           [ shCmdArg, [ exec ].concat(args).join(' ')],
-          { cwd: cwd, env: env }
+          { cwd: cwd, env: env, stdio: ['ignore', null, null] }
         );
       } else {
         this.child = require('cross-spawn').spawn(
           exec,
           args,
-          { cwd: cwd, env: env }
+          { cwd: cwd, env: env, stdio: ['ignore', null, null] }
         );
       }
 


### PR DESCRIPTION
If we don't close stdin, subprocesses that would ask for user input
block forever. Since atom-build has no way to interact with the spawned
subprocesses, just close it to have them fail.