### PR TITLE
Patch 1

### DIFF
--- a/lib/atom-build.js
+++ b/lib/atom-build.js
@@ -5,23 +5,51 @@ import EventEmitter from 'events';
 function getConfig(file) {
   const fs = require('fs');
   const realFile = fs.realpathSync(file);
-  delete require.cache[realFile];
+  const contents = fs.readFileSync(realFile);
+
+  function fromScript(script) {
+    const globals = {
+      __dirname: require('path').dirname(realFile),
+      __filename: realFile,
+      module: { exports: {} },
+      require
+    };
+    globals.exports = globals.module.exports;
+    const scriptFn = new Function(...Object.keys(globals), script);
+    scriptFn(...Object.keys(globals).map(n => globals[n]));
+    return globals.module.exports;
+  };
+
   switch (require('path').extname(file)) {
     case '.json':
+      return JSON.parse(contents);
+
     case '.js':
-      return require(realFile);
+      return fromScript(contents);
+
+    case '.coffee':
+      let coffee;
+      try
+      {
+        coffee = require('coffeescript');
+      }
+      catch (e) {}
+      if (coffee === undefined)
+      {
+        coffee = require('coffee-script');
+      }
+      return fromScript(coffee.compile(contents, { bare: true }));
 
     case '.cson':
-      return require('cson-parser').parse(fs.readFileSync(realFile));
+      return require('cson-parser').parse(contents);
 
     case '.yaml':
     case '.yml':
-      return require('js-yaml').safeLoad(fs.readFileSync(realFile));
+      return require('js-yaml').safeLoad(contents);
   }
 
   return {};
 }
-
 function createBuildConfig(build, name) {
   const conf = {
     name: 'Custom: ' + name,

--- a/lib/atom-build.js
+++ b/lib/atom-build.js
@@ -96,7 +96,7 @@ export default class CustomFile extends EventEmitter {
     const os = require('os');
     const fs = require('fs');
     const path = require('path');
-    this.files = [].concat.apply([], [ 'json', 'cson', 'yaml', 'yml', 'js' ].map(ext => [
+    this.files = [].concat.apply([], [ 'json', 'cson', 'yaml', 'yml', 'js', 'coffee' ].map(ext => [
       path.join(this.cwd, `.atom-build.${ext}`),
       path.join(os.homedir(), `.atom-build.${ext}`)
     ])).filter(fs.existsSync);

--- a/spec/custom-provider-spec.js
+++ b/spec/custom-provider-spec.js
@@ -144,4 +144,20 @@ describe('custom provider', () => {
       });
     });
   });
+  
+  describe('when .atom-build.coffee exists', () => {
+    it('it should provide targets', () => {
+      fs.writeFileSync(`${directory}.atom-build.coffee`, fs.readFileSync(`${__dirname}/fixture/.atom-build.coffee`));
+      expect(builder.isEligible()).toEqual(true);
+
+      waitsForPromise(() => {
+        return Promise.resolve(builder.settings()).then(settings => {
+          const s = settings[0];
+          expect(s.exec).toEqual('echo');
+          expect(s.args).toEqual([ 'hello', 'world', 'from', 'coffeescript' ]);
+          expect(s.name).toEqual('Custom: from coffeescript');
+        });
+      });
+    });
+  });
 });

--- a/spec/fixture/.atom-build.coffee
+++ b/spec/fixture/.atom-build.coffee
@@ -1,0 +1,4 @@
+module.exports =
+  cmd: 'echo'
+  args: [ 'hello', 'world', 'from', 'js' ]
+  name: 'from js'


### PR DESCRIPTION
Fixes noseglid#527 by not using require() to load `.atom-build.*`

Coffeescript noseglid#513 was easy to add after that. Did I miss any tests I should've added?