### PR TITLE
check all project folders to find error matched file

### DIFF
--- a/lib/error-matcher.js
+++ b/lib/error-matcher.js
@@ -45,23 +45,42 @@ export default class ErrorMatcher extends EventEmitter {
     }
 
     const path = require('path');
+    const fs = require('fs');
+
     if (!path.isAbsolute(file)) {
-      file = this.cwd + path.sep + file;
+      absfile = path.normalize(this.cwd + path.sep + file);
     }
 
     const row = match.line ? match.line - 1 : 0; /* Because atom is zero-based */
     const col = match.col ? match.col - 1 : 0; /* Because atom is zero-based */
 
-    require('fs').exists(file, (exists) => {
+    fs.exists(absfile, (exists) => {
       if (!exists) {
-        this.emit('error', 'Matched file does not exist: ' + file);
-        return;
-      }
-      atom.workspace.open(file, {
-        initialLine: row,
-        initialColumn: col,
-        searchAllPanes: true
-      });
+          var pths = atom.workspace.project.getPaths();
+          for (idx=0;idx<pths.length;idx++)
+          {
+            newfile = path.normalize(pths[idx]+path.sep+file);
+            if (newfile!=absfile)
+            {
+              fs.exists(newfile, (exsts) => {
+                if (exsts) {
+                  atom.workspace.open(newfile, {
+                          initialLine: row,
+                          initialColumn: col,
+                          searchAllPanes: true
+                        });
+                  return;
+                }
+              });
+            }
+          }
+        }
+      else
+        atom.workspace.open(absfile, {
+          initialLine: row,
+          initialColumn: col,
+          searchAllPanes: true
+        });
       this.emit('matched', match);
     });
   }


### PR DESCRIPTION
With atom-build-waf and some wscript_build builds in sub folders, it failed to open the file. Instead there was a warning, the file does not exist.
There is a similar problem AtomBuild/atom-build-make#21

With this change, if one adds the subfolder to the project, the file can be found.
