### PR TITLE
Fix uglifyed message.

### DIFF
--- a/lib/build.js
+++ b/lib/build.js
@@ -1,5 +1,7 @@
 'use babel';
 
+let iconv = require('iconv-lite');
+
 export default {
   config: require('./config'),
 
@@ -18,6 +20,7 @@ export default {
     this.tools = [ require('./atom-build') ];
     this.linter = null;
 
+    this.detectConsoleEncoding()
     this.setupTargetManager();
     this.setupBuildView();
     this.setupErrorMatcher();
@@ -45,6 +48,21 @@ export default {
 
     atom.workspace.onDidChangeActivePaneItem(() => this.updateStatusBar());
     atom.packages.onDidActivateInitialPackages(() => this.targetManager.refreshTargets());
+  },
+
+  detectConsoleEncoding() {
+    this.encoding = "utf8";
+
+    if (process.platform === "win32") {
+      // On windows, `chcp` commnad prints current console codepage.
+      // see: https://ss64.com/nt/chcp.html
+      require("child_process").exec("chcp", (err, stdout, stderr) => {
+        if (stdout) {
+          let i = stdout.lastIndexOf(":");
+          this.encoding = "cp" + stdout.slice(i + 1).trim();
+        }
+      });
+    }
   },
 
   setupTargetManager() {
@@ -163,12 +181,12 @@ export default {
 
       let stdout = '';
       let stderr = '';
-      this.child.stdout.setEncoding('utf8');
-      this.child.stderr.setEncoding('utf8');
-      this.child.stdout.on('data', d => (stdout += d));
-      this.child.stderr.on('data', d => (stderr += d));
-      this.child.stdout.pipe(this.buildView.terminal);
-      this.child.stderr.pipe(this.buildView.terminal);
+      let decodeStdout = this.child.stdout.pipe(iconv.decodeStream(this.encoding));
+      let decodeStderr = this.child.stderr.pipe(iconv.decodeStream(this.encoding));
+      decodeStdout.on('data', d => (stdout += d));
+      decodeStderr.on('data', d => (stderr += d));
+      decodeStdout.pipe(this.buildView.terminal);
+      decodeStderr.pipe(this.buildView.terminal);
       this.child.killSignals = (target.killSignals || [ 'SIGINT', 'SIGTERM', 'SIGKILL' ]).slice();
 
       this.child.on('error', (err) => {

--- a/lib/build.js
+++ b/lib/build.js
@@ -1,7 +1,5 @@
 'use babel';
 
-let iconv = require('iconv-lite');
-
 export default {
   config: require('./config'),
 
@@ -20,7 +18,7 @@ export default {
     this.tools = [ require('./atom-build') ];
     this.linter = null;
 
-    this.detectConsoleEncoding()
+    this.detectConsoleEncoding();
     this.setupTargetManager();
     this.setupBuildView();
     this.setupErrorMatcher();
@@ -51,15 +49,15 @@ export default {
   },
 
   detectConsoleEncoding() {
-    this.encoding = "utf8";
+    this.encoding = 'utf8';
 
-    if (process.platform === "win32") {
+    if (process.platform === 'win32') {
       // On windows, `chcp` commnad prints current console codepage.
       // see: https://ss64.com/nt/chcp.html
-      require("child_process").exec("chcp", (err, stdout, stderr) => {
+      require('child_process').exec('chcp', (err, stdout, stderr) => {
         if (stdout) {
-          let i = stdout.lastIndexOf(":");
-          this.encoding = "cp" + stdout.slice(i + 1).trim();
+          const i = stdout.lastIndexOf(':');
+          this.encoding = 'cp' + stdout.slice(i + 1).trim();
         }
       });
     }
@@ -179,10 +177,11 @@ export default {
         );
       }
 
+      const iconv = require('iconv-lite');
       let stdout = '';
       let stderr = '';
-      let decodeStdout = this.child.stdout.pipe(iconv.decodeStream(this.encoding));
-      let decodeStderr = this.child.stderr.pipe(iconv.decodeStream(this.encoding));
+      const decodeStdout = this.child.stdout.pipe(iconv.decodeStream(this.encoding));
+      const decodeStderr = this.child.stderr.pipe(iconv.decodeStream(this.encoding));
       decodeStdout.on('data', d => (stdout += d));
       decodeStderr.on('data', d => (stderr += d));
       decodeStdout.pipe(this.buildView.terminal);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cross-spawn": "^4.0.2",
     "cson-parser": "^1.3.0",
     "getmac": "^1.0.7",
+    "iconv-lite": "^0.4.23",
     "js-yaml": "^3.4.6",
     "term.js": "https://github.com/jeremyramin/term.js/tarball/de1635fc2695e7d8165012d3b1d007d7ce60eea2",
     "tree-kill": "^1.0.0",


### PR DESCRIPTION
Fix #473 and #531.

Implement converting `stdout` / `stderr` of build command with encoding extracted by `chcp` command.

This method is based on Visual Studio Code.
https://github.com/Microsoft/vscode/blob/release/1.25/src/vs/base/node/encoding.ts#L397

It's work well on my Japanese, Windows 10 x64 environment.