### PR TITLE
Add linter v2 integration

### DIFF
--- a/lib/linter-integration.js
+++ b/lib/linter-integration.js
@@ -59,7 +59,7 @@ class Linter {
         file: normalizePath(match.file),
         position: extractRange(match)
       },
-      excerpt: !match.message && !match.html_message ? 'Error from build' : match.message,
+      excerpt: !match.message && !match.html_message ? 'Error from build' : match.message
     }));
 
     if (this.linter.setAllMessages) {

--- a/lib/linter-integration.js
+++ b/lib/linter-integration.js
@@ -2,13 +2,23 @@
 
 class Linter {
   constructor(registry) {
-    this.linter = registry.register({ name: 'Build' });
+    const options = { name: 'Build' };
+
+    if (registry.register) {
+      this.linter = registry.register(options);
+    } else {
+      this.linter = registry(options);
+    }
   }
   destroy() {
     this.linter.dispose();
   }
   clear() {
-    this.linter.deleteMessages();
+    if (this.linter.clearMessages) {
+      this.linter.clearMessages();
+    } else {
+      this.linter.deleteMessages();
+    }
   }
   processMessages(messages, cwd) {
     function extractRange(json) {
@@ -29,7 +39,8 @@ class Linter {
         default: return null;
       }
     }
-    this.linter.setMessages(messages.map(match => ({
+
+    messages = messages.map(match => ({
       type: match.type || 'Error',
       text: !match.message && !match.html_message ? 'Error from build' : match.message,
       html: match.message ? undefined : match.html_message,
@@ -43,8 +54,19 @@ class Linter {
         filePath: trace.file && normalizePath(trace.file),
         severity: typeToSeverity(trace.type) || 'info',
         range: extractRange(trace)
-      }))
-    })));
+      })),
+      location: {
+        file: normalizePath(match.file),
+        position: extractRange(match)
+      },
+      excerpt: !match.message && !match.html_message ? 'Error from build' : match.message,
+    }));
+
+    if (this.linter.setAllMessages) {
+      this.linter.setAllMessages(messages);
+    } else {
+      this.linter.setMessages(messages);
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     },
     "linter-indie": {
       "versions": {
-        "1.0.0": "consumeLinterRegistry"
+        "^1.0.0": "consumeLinterRegistry",
+        "^2.0.0": "consumeLinterRegistry"
       }
     }
   },


### PR DESCRIPTION
This PR adds [indie-linter v2](https://steelbrain.me/linter/guides/upgrading-to-indie-linter-v2.html) support, while maintaining v1 support.
It should fix  #577 - at least it did it for me.